### PR TITLE
Mark workouts complete with RPE and optional session metrics

### DIFF
--- a/Dropped/Models/UserData.swift
+++ b/Dropped/Models/UserData.swift
@@ -228,6 +228,7 @@ class WorkoutManager {
     static let shared = WorkoutManager()
     private let workoutsKey = "com.dropped.workouts"
     private let workoutDaysKey = "com.dropped.workoutDays"
+    private let workoutLogsKey = "com.dropped.workoutLogs"
     private let defaults: UserDefaults
     
     private init(defaults: UserDefaults = .standard) {
@@ -328,6 +329,54 @@ class WorkoutManager {
     func resetWorkouts() {
         defaults.removeObject(forKey: workoutsKey)
         defaults.removeObject(forKey: workoutDaysKey)
+        defaults.removeObject(forKey: workoutLogsKey)
+    }
+
+    // MARK: - WorkoutLog Management
+
+    /// Persist a completion log. Replaces any existing log with the same `id`,
+    /// otherwise appends the new entry.
+    func saveLog(_ log: WorkoutLog) {
+        var logs = loadLogs()
+
+        if let index = logs.firstIndex(where: { $0.id == log.id }) {
+            logs[index] = log
+        } else {
+            logs.append(log)
+        }
+
+        saveLogs(logs)
+    }
+
+    /// Load every persisted `WorkoutLog`. Returns an empty array when none
+    /// exist or the stored payload is unreadable.
+    func loadLogs() -> [WorkoutLog] {
+        guard let data = defaults.data(forKey: workoutLogsKey),
+              let logs = try? JSONDecoder().decode([WorkoutLog].self, from: data) else {
+            return []
+        }
+
+        return logs
+    }
+
+    /// Look up the most recent log for a given workout ID.
+    ///
+    /// The current model assumes one log per workout, but the API is keyed by
+    /// `workoutID` (not log id) so we can safely relax that invariant later
+    /// without changing call sites.
+    func log(forWorkoutID workoutID: UUID) -> WorkoutLog? {
+        loadLogs()
+            .filter { $0.workoutID == workoutID }
+            .max(by: { $0.completedAt < $1.completedAt })
+    }
+
+    /// Remove every log associated with a workout. No-op when no logs match.
+    func deleteLog(forWorkoutID workoutID: UUID) {
+        var logs = loadLogs()
+        let originalCount = logs.count
+        logs.removeAll { $0.workoutID == workoutID }
+        guard logs.count != originalCount else { return }
+        saveLogs(logs)
     }
 
     private func saveWorkouts(_ workouts: [Workout]) {
@@ -346,5 +395,14 @@ class WorkoutManager {
         }
 
         defaults.set(data, forKey: workoutDaysKey)
+    }
+
+    private func saveLogs(_ logs: [WorkoutLog]) {
+        guard let data = try? JSONEncoder().encode(logs) else {
+            assertionFailure("Failed to encode workout logs.")
+            return
+        }
+
+        defaults.set(data, forKey: workoutLogsKey)
     }
 }

--- a/Dropped/Models/WorkoutLog.swift
+++ b/Dropped/Models/WorkoutLog.swift
@@ -1,0 +1,139 @@
+//
+//  WorkoutLog.swift
+//  Dropped
+//
+//  Persisted record of a completed workout. A `WorkoutLog` captures what
+//  actually happened during a session (perceived exertion, optional power /
+//  heart-rate / duration metrics, freeform notes) and is keyed back to the
+//  scheduled `Workout` it completes. Workouts represent the plan; logs
+//  represent the actuals.
+//
+//  The model is intentionally forward-compatible with future surfaces
+//  (adaptation, streaks, charts, TSS). It snapshots the rider's `UserData`
+//  at completion time so derived metrics like Intensity Factor (IF) and
+//  Training Stress Score (TSS) can be recomputed accurately later, even
+//  if the rider's FTP changes.
+//
+
+import Foundation
+
+/// A persisted record of a completed workout session.
+///
+/// One log corresponds to a single completion of a scheduled `Workout`,
+/// linked via `workoutID`. Optional metrics may be left `nil` when the
+/// rider did not record them (e.g. no power meter, no heart-rate strap).
+struct WorkoutLog: Identifiable, Codable, Equatable {
+    /// Valid range for Rate of Perceived Exertion (Borg CR10-style).
+    static let rpeRange: ClosedRange<Int> = 1...10
+
+    let id: UUID
+    /// Identifier of the scheduled `Workout` this log completes.
+    let workoutID: UUID
+    /// When the rider marked the workout complete. Defaults to "now" but is
+    /// editable so past sessions can be back-logged.
+    var completedAt: Date
+    /// Rider's perceived exertion on the 1–10 scale. Always clamped into
+    /// `rpeRange` by the initializer so persisted data stays valid.
+    var perceivedExertion: Int
+    /// Average power for the session in watts. Optional.
+    var averagePower: Int?
+    /// Average heart rate for the session in bpm. Optional.
+    var averageHeartRate: Int?
+    /// Override for the session's actual duration (seconds). When `nil` the
+    /// planned `Workout.totalDuration` is used.
+    var durationOverride: TimeInterval?
+    /// Freeform rider notes about how the session went.
+    var notes: String?
+    /// Snapshot of the rider's `UserData` at log time. Captured so future
+    /// recomputations (TSS, IF, weight-relative power) remain accurate.
+    let userDataSnapshot: UserData
+
+    /// Designated initializer.
+    ///
+    /// - Parameters:
+    ///   - id: Stable identifier for the log itself. Defaults to a new UUID.
+    ///   - workoutID: Identifier of the scheduled `Workout` being completed.
+    ///   - completedAt: Timestamp the rider attributes to the session.
+    ///   - perceivedExertion: RPE value; values outside `rpeRange` are clamped.
+    ///   - averagePower: Optional average power in watts.
+    ///   - averageHeartRate: Optional average heart rate in bpm.
+    ///   - durationOverride: Optional actual duration in seconds.
+    ///   - notes: Optional freeform rider notes. Empty/whitespace-only strings
+    ///     are normalized to `nil`.
+    ///   - userDataSnapshot: Rider profile snapshot captured at log time.
+    init(
+        id: UUID = UUID(),
+        workoutID: UUID,
+        completedAt: Date,
+        perceivedExertion: Int,
+        averagePower: Int? = nil,
+        averageHeartRate: Int? = nil,
+        durationOverride: TimeInterval? = nil,
+        notes: String? = nil,
+        userDataSnapshot: UserData
+    ) {
+        self.id = id
+        self.workoutID = workoutID
+        self.completedAt = completedAt
+        self.perceivedExertion = WorkoutLog.clampRPE(perceivedExertion)
+        self.averagePower = averagePower
+        self.averageHeartRate = averageHeartRate
+        self.durationOverride = durationOverride
+        self.notes = WorkoutLog.normalize(notes)
+        self.userDataSnapshot = userDataSnapshot
+    }
+
+    // MARK: - Derived metrics
+
+    /// Returns the duration we should attribute to this session, falling back
+    /// to the planned duration when the rider did not provide an override.
+    ///
+    /// - Parameter planned: The `Workout.totalDuration` of the scheduled session.
+    /// - Returns: `durationOverride` when set, otherwise `planned`.
+    func effectiveDuration(planned: TimeInterval) -> TimeInterval {
+        durationOverride ?? planned
+    }
+
+    /// Intensity Factor (IF) — average power as a fraction of the snapshot
+    /// FTP. Returns `nil` when average power is unknown or FTP is non-positive.
+    ///
+    /// IF is the ratio used by TSS and many adaptation models. We expose it
+    /// even though no UI surfaces it yet, so future charts and TSS can use a
+    /// single shared definition.
+    var intensityFactor: Double? {
+        guard let averagePower, userDataSnapshot.ftp > 0 else { return nil }
+        return Double(averagePower) / Double(userDataSnapshot.ftp)
+    }
+
+    /// Estimated Training Stress Score for this session.
+    ///
+    /// Uses the standard simplified formula `TSS = duration_hours * IF^2 * 100`.
+    /// Returns `nil` when `intensityFactor` cannot be computed or the effective
+    /// duration is non-positive.
+    ///
+    /// - Parameter planned: The planned duration to fall back to when the
+    ///   rider did not provide a `durationOverride`.
+    func estimatedTSS(planned: TimeInterval) -> Double? {
+        guard let intensityFactor else { return nil }
+        let duration = effectiveDuration(planned: planned)
+        guard duration > 0 else { return nil }
+        let durationHours = duration / 3600.0
+        return durationHours * intensityFactor * intensityFactor * 100.0
+    }
+
+    // MARK: - Helpers
+
+    /// Clamp an arbitrary integer into the supported RPE range.
+    static func clampRPE(_ value: Int) -> Int {
+        min(max(value, rpeRange.lowerBound), rpeRange.upperBound)
+    }
+
+    /// Normalize freeform notes — treats empty / whitespace-only strings as `nil`.
+    private static func normalize(_ notes: String?) -> String? {
+        guard let trimmed = notes?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else {
+            return nil
+        }
+        return trimmed
+    }
+}

--- a/Dropped/ViewModels/WorkoutLogViewModel.swift
+++ b/Dropped/ViewModels/WorkoutLogViewModel.swift
@@ -1,0 +1,111 @@
+//
+//  WorkoutLogViewModel.swift
+//  Dropped
+//
+//  Form-state owner for the "Mark workout complete" sheet. The view model
+//  exposes editable fields backed by the optional metrics on `WorkoutLog`,
+//  validates RPE, and bridges Save / Delete actions back to the
+//  `WorkoutManager` persistence layer.
+//
+
+import Foundation
+import SwiftUI
+
+/// Drives the workout-completion sheet.
+///
+/// The view model is initialized with the `Workout` being completed and an
+/// optional existing `WorkoutLog`. When an existing log is provided the form
+/// pre-populates with its values and `isEditing` becomes `true` so the UI can
+/// surface "Update" + "Remove Log" affordances instead of plain "Save".
+@MainActor
+final class WorkoutLogViewModel: ObservableObject {
+    /// The workout the rider is logging a completion for.
+    let workout: Workout
+
+    /// Existing log id when editing an entry, otherwise `nil` (new log).
+    private let existingLogID: UUID?
+
+    /// `true` when the rider opened the sheet to edit an existing log.
+    var isEditing: Bool { existingLogID != nil }
+
+    // MARK: - Form fields
+
+    @Published var completedAt: Date
+    @Published var perceivedExertion: Int
+    @Published var includeAveragePower: Bool
+    @Published var averagePowerText: String
+    @Published var includeAverageHeartRate: Bool
+    @Published var averageHeartRateText: String
+    @Published var includeDurationOverride: Bool
+    /// Duration override expressed in **minutes** for rider-friendly entry.
+    @Published var durationOverrideMinutesText: String
+    @Published var notes: String
+
+    // MARK: - Init
+
+    init(workout: Workout, existingLog: WorkoutLog? = nil) {
+        self.workout = workout
+        self.existingLogID = existingLog?.id
+
+        if let log = existingLog {
+            self.completedAt = log.completedAt
+            self.perceivedExertion = log.perceivedExertion
+            self.includeAveragePower = log.averagePower != nil
+            self.averagePowerText = log.averagePower.map(String.init) ?? ""
+            self.includeAverageHeartRate = log.averageHeartRate != nil
+            self.averageHeartRateText = log.averageHeartRate.map(String.init) ?? ""
+            self.includeDurationOverride = log.durationOverride != nil
+            self.durationOverrideMinutesText = log.durationOverride.map { String(Int(($0 / 60).rounded())) } ?? ""
+            self.notes = log.notes ?? ""
+        } else {
+            self.completedAt = Date()
+            self.perceivedExertion = 5
+            self.includeAveragePower = false
+            self.averagePowerText = ""
+            self.includeAverageHeartRate = false
+            self.averageHeartRateText = ""
+            self.includeDurationOverride = false
+            self.durationOverrideMinutesText = String(Int((workout.totalDuration / 60).rounded()))
+            self.notes = ""
+        }
+    }
+
+    /// RPE bounds exposed to the view layer.
+    var rpeRange: ClosedRange<Int> { WorkoutLog.rpeRange }
+
+    /// Save button label changes copy when editing vs. creating.
+    var saveButtonTitle: String { isEditing ? "Update Log" : "Save Log" }
+
+    /// Builds a `WorkoutLog` from the current form state and persists it.
+    /// Returns the saved log so the caller can refresh local UI state.
+    @discardableResult
+    func save(manager: WorkoutManager = .shared,
+              userDataManager: UserDataManager = .shared) -> WorkoutLog {
+        let log = WorkoutLog(
+            id: existingLogID ?? UUID(),
+            workoutID: workout.id,
+            completedAt: completedAt,
+            perceivedExertion: perceivedExertion,
+            averagePower: includeAveragePower ? Int(averagePowerText.trimmingCharacters(in: .whitespaces)) : nil,
+            averageHeartRate: includeAverageHeartRate ? Int(averageHeartRateText.trimmingCharacters(in: .whitespaces)) : nil,
+            durationOverride: includeDurationOverride ? parsedDurationSeconds() : nil,
+            notes: notes,
+            userDataSnapshot: userDataManager.loadUserData()
+        )
+        manager.saveLog(log)
+        return log
+    }
+
+    /// Removes any logs associated with this workout. Used by "Remove Log".
+    func deleteLog(manager: WorkoutManager = .shared) {
+        manager.deleteLog(forWorkoutID: workout.id)
+    }
+
+    // MARK: - Helpers
+
+    private func parsedDurationSeconds() -> TimeInterval? {
+        let trimmed = durationOverrideMinutesText.trimmingCharacters(in: .whitespaces)
+        guard let minutes = Double(trimmed), minutes > 0 else { return nil }
+        return minutes * 60.0
+    }
+}

--- a/Dropped/Views/PlanSummaryView.swift
+++ b/Dropped/Views/PlanSummaryView.swift
@@ -12,6 +12,7 @@ import Foundation
 struct PlanSummaryView: View {
     @State private var userData: UserData
     @State private var workouts: [Workout] = []
+    @State private var logsByWorkoutID: [UUID: WorkoutLog] = [:]
     @Binding var hasCompletedOnboarding: Bool
     
     init(hasCompletedOnboarding: Binding<Bool>) {
@@ -61,7 +62,7 @@ struct PlanSummaryView: View {
                         
                         ForEach(workoutPlan) { workout in
                             NavigationLink(destination: WorkoutDetailView(workout: workout)) {
-                                WorkoutCard(workout: workout)
+                                WorkoutCard(workout: workout, log: logsByWorkoutID[workout.id])
                             }
                         }
                     }
@@ -72,6 +73,7 @@ struct PlanSummaryView: View {
                         UserDataManager.shared.resetUserData()
                         WorkoutManager.shared.resetWorkouts()
                         workouts = []
+                        logsByWorkoutID = [:]
                         hasCompletedOnboarding = false
                     }) {
                         HStack {
@@ -128,6 +130,23 @@ struct PlanSummaryView: View {
             }
             workouts = generatedWorkouts
         }
+
+        refreshLogs()
+    }
+
+    /// Loads completion logs and indexes them by `workoutID` so cards can look
+    /// up their state in O(1).
+    private func refreshLogs() {
+        let logs = WorkoutManager.shared.loadLogs()
+        var index: [UUID: WorkoutLog] = [:]
+        for log in logs {
+            // Keep the most recent log per workout in case multiple ever exist.
+            if let existing = index[log.workoutID], existing.completedAt > log.completedAt {
+                continue
+            }
+            index[log.workoutID] = log
+        }
+        logsByWorkoutID = index
     }
     
     /// Generates a workout plan based on user's training hours per week and goal
@@ -420,7 +439,9 @@ struct StatCard: View {
 /// Card view for displaying workout information
 struct WorkoutCard: View {
     let workout: Workout
-    
+    /// Optional completion log; when present, the card renders a completion badge.
+    var log: WorkoutLog? = nil
+
     var intensityColor: Color {
         // Calculate intensity from intervals
         let avgPower = workout.averagePower
@@ -474,6 +495,10 @@ struct WorkoutCard: View {
                     .foregroundColor(.primary)
                 
                 Spacer()
+
+                if let log {
+                    completionBadge(for: log)
+                }
                 
                 Text(durationText)
                     .font(.subheadline)
@@ -516,6 +541,33 @@ struct WorkoutCard: View {
         .padding(.horizontal)
         .padding(.bottom, 5)
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(dayOfWeek), \(workout.title) workout. \(durationText). Intensity: \(intensityText). \(workout.summary)")
+        .accessibilityLabel(accessibilitySummary)
+    }
+
+    /// Compact "Completed · RPE n" badge shown on logged workouts.
+    private func completionBadge(for log: WorkoutLog) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: "checkmark.seal.fill")
+                .foregroundColor(.green)
+                .font(.caption)
+            Text("RPE \(log.perceivedExertion)")
+                .font(.caption)
+                .fontWeight(.semibold)
+                .foregroundColor(.green)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(Color.green.opacity(0.12))
+        )
+    }
+
+    private var accessibilitySummary: String {
+        var summary = "\(dayOfWeek), \(workout.title) workout. \(durationText). Intensity: \(intensityText). \(workout.summary)"
+        if let log {
+            summary += ". Completed, RPE \(log.perceivedExertion) of 10."
+        }
+        return summary
     }
 }

--- a/Dropped/Views/WorkoutDetailView.swift
+++ b/Dropped/Views/WorkoutDetailView.swift
@@ -5,18 +5,57 @@ struct WorkoutDetailView: View {
     /// The workout to display.
     let workout: Workout
 
+    /// The persisted completion log for this workout, if one exists.
+    @State private var log: WorkoutLog?
+    /// Drives presentation of the `WorkoutLogSheet`.
+    @State private var isShowingLogSheet = false
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 24) {
                 WorkoutOverviewHeader(workout: workout)
+                if let log {
+                    WorkoutLogSummaryCard(log: log, plannedDuration: workout.totalDuration)
+                }
                 intervalsSection
                 powerProfileSection
+                completionCTA
             }
             .padding([.horizontal, .bottom])
         }
         .background(Color(UIColor.systemBackground))
         .navigationTitle("Workout Details")
         .navigationBarTitleDisplayMode(.inline)
+        .onAppear(perform: refreshLog)
+        .sheet(isPresented: $isShowingLogSheet) {
+            WorkoutLogSheet(workout: workout, existingLog: log) {
+                refreshLog()
+            }
+        }
+    }
+
+    /// CTA toggles between marking complete and editing an existing log.
+    private var completionCTA: some View {
+        Button {
+            isShowingLogSheet = true
+        } label: {
+            HStack {
+                Image(systemName: log == nil ? "checkmark.circle" : "square.and.pencil")
+                Text(log == nil ? "Mark Complete" : "Edit Log")
+                    .font(.headline)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 14)
+            .foregroundColor(.white)
+            .background((log == nil ? Color.green : Color.blue).gradient)
+            .cornerRadius(12)
+        }
+        .accessibilityLabel(log == nil ? "Mark workout complete" : "Edit completion log")
+        .padding(.top, 8)
+    }
+
+    private func refreshLog() {
+        log = WorkoutManager.shared.log(forWorkoutID: workout.id)
     }
 
     /// List of workout intervals, or an empty state if the workout has none.
@@ -134,6 +173,95 @@ private struct IntervalRow: View {
         )
         .accessibilityElement(children: .combine)
         .accessibilityLabel("Interval \(index), Power \(interval.watts) watts, Duration \(formattedDuration)")
+    }
+}
+
+/// Summary card shown at the top of the detail view when a log exists.
+private struct WorkoutLogSummaryCard: View {
+    let log: WorkoutLog
+    let plannedDuration: TimeInterval
+
+    private var formattedDate: String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return formatter.string(from: log.completedAt)
+    }
+
+    private var formattedDuration: String {
+        let minutes = Int(log.effectiveDuration(planned: plannedDuration) / 60)
+        return "\(minutes) min"
+    }
+
+    private var accessibilitySummary: String {
+        var parts: [String] = ["Completed \(formattedDate)", "RPE \(log.perceivedExertion) of 10"]
+        if let avgPower = log.averagePower { parts.append("Average power \(avgPower) watts") }
+        if let avgHR = log.averageHeartRate { parts.append("Average heart rate \(avgHR) bpm") }
+        parts.append("Duration \(formattedDuration)")
+        if let notes = log.notes { parts.append("Notes: \(notes)") }
+        return parts.joined(separator: ". ")
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 8) {
+                Image(systemName: "checkmark.seal.fill")
+                    .foregroundColor(.green)
+                Text("Completed")
+                    .font(.headline)
+                Spacer()
+                Text(formattedDate)
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            }
+
+            HStack(spacing: 12) {
+                LogMetric(label: "RPE", value: "\(log.perceivedExertion)/10")
+                LogMetric(label: "Duration", value: formattedDuration)
+                if let avgPower = log.averagePower {
+                    LogMetric(label: "Avg Power", value: "\(avgPower) W")
+                }
+                if let avgHR = log.averageHeartRate {
+                    LogMetric(label: "Avg HR", value: "\(avgHR) bpm")
+                }
+            }
+
+            if let notes = log.notes {
+                Text(notes)
+                    .font(.body)
+                    .foregroundColor(.primary)
+                    .padding(.top, 4)
+            }
+        }
+        .padding()
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color.green.opacity(0.08))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(Color.green.opacity(0.4), lineWidth: 1)
+        )
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilitySummary)
+    }
+}
+
+/// Compact metric chip used inside `WorkoutLogSummaryCard`.
+private struct LogMetric: View {
+    let label: String
+    let value: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(label)
+                .font(.caption)
+                .foregroundColor(.secondary)
+            Text(value)
+                .font(.subheadline)
+                .fontWeight(.semibold)
+        }
+        .accessibilityHidden(true)
     }
 }
 

--- a/Dropped/Views/WorkoutLogSheet.swift
+++ b/Dropped/Views/WorkoutLogSheet.swift
@@ -1,0 +1,175 @@
+//
+//  WorkoutLogSheet.swift
+//  Dropped
+//
+//  Modal form used to mark a workout complete and capture the rider's
+//  perceived exertion, optional metrics, and notes. The sheet doubles as the
+//  edit + un-complete surface when an existing `WorkoutLog` is present.
+//
+
+import SwiftUI
+
+/// Sheet form for creating or editing a `WorkoutLog`.
+///
+/// Presents the rider with a required RPE slider plus optional fields for
+/// average power, average heart rate, duration override, and freeform notes.
+/// All persistence is delegated to `WorkoutLogViewModel`.
+struct WorkoutLogSheet: View {
+    @StateObject private var viewModel: WorkoutLogViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    /// Callback fired after a successful save or delete so the parent view
+    /// can refresh its local state.
+    private let onChange: () -> Void
+
+    init(workout: Workout,
+         existingLog: WorkoutLog? = nil,
+         onChange: @escaping () -> Void) {
+        self._viewModel = StateObject(
+            wrappedValue: WorkoutLogViewModel(workout: workout, existingLog: existingLog)
+        )
+        self.onChange = onChange
+    }
+
+    var body: some View {
+        NavigationView {
+            Form {
+                completionSection
+                exertionSection
+                metricsSection
+                notesSection
+                if viewModel.isEditing {
+                    removeSection
+                }
+            }
+            .navigationTitle(viewModel.isEditing ? "Edit Log" : "Mark Complete")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(viewModel.saveButtonTitle) {
+                        viewModel.save()
+                        onChange()
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Sections
+
+    private var completionSection: some View {
+        Section(header: Text("Completion")) {
+            DatePicker(
+                "Completed",
+                selection: $viewModel.completedAt,
+                displayedComponents: [.date, .hourAndMinute]
+            )
+            .accessibilityLabel("Completion date and time")
+        }
+    }
+
+    private var exertionSection: some View {
+        Section(header: Text("Perceived Exertion")) {
+            HStack {
+                Text("RPE")
+                Spacer()
+                Text("\(viewModel.perceivedExertion) / \(viewModel.rpeRange.upperBound)")
+                    .font(.headline)
+                    .monospacedDigit()
+            }
+            .accessibilityElement(children: .combine)
+
+            Slider(
+                value: Binding(
+                    get: { Double(viewModel.perceivedExertion) },
+                    set: { viewModel.perceivedExertion = WorkoutLog.clampRPE(Int($0.rounded())) }
+                ),
+                in: Double(viewModel.rpeRange.lowerBound)...Double(viewModel.rpeRange.upperBound),
+                step: 1
+            )
+            .accessibilityLabel("Rate of perceived exertion")
+            .accessibilityValue("\(viewModel.perceivedExertion) out of \(viewModel.rpeRange.upperBound)")
+        }
+    }
+
+    private var metricsSection: some View {
+        Section(header: Text("Optional Metrics")) {
+            Toggle("Log average power", isOn: $viewModel.includeAveragePower)
+            if viewModel.includeAveragePower {
+                metricField(
+                    title: "Avg power",
+                    text: $viewModel.averagePowerText,
+                    suffix: "W",
+                    accessibility: "Average power in watts"
+                )
+            }
+
+            Toggle("Log average heart rate", isOn: $viewModel.includeAverageHeartRate)
+            if viewModel.includeAverageHeartRate {
+                metricField(
+                    title: "Avg HR",
+                    text: $viewModel.averageHeartRateText,
+                    suffix: "bpm",
+                    accessibility: "Average heart rate in beats per minute"
+                )
+            }
+
+            Toggle("Override duration", isOn: $viewModel.includeDurationOverride)
+            if viewModel.includeDurationOverride {
+                metricField(
+                    title: "Duration",
+                    text: $viewModel.durationOverrideMinutesText,
+                    suffix: "min",
+                    accessibility: "Actual duration in minutes"
+                )
+            }
+        }
+    }
+
+    private var notesSection: some View {
+        Section(header: Text("Notes")) {
+            TextEditor(text: $viewModel.notes)
+                .frame(minHeight: 96)
+                .accessibilityLabel("Session notes")
+        }
+    }
+
+    private var removeSection: some View {
+        Section {
+            Button(role: .destructive) {
+                viewModel.deleteLog()
+                onChange()
+                dismiss()
+            } label: {
+                HStack {
+                    Image(systemName: "trash")
+                    Text("Remove Log")
+                }
+            }
+            .accessibilityLabel("Remove completion log")
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func metricField(title: String,
+                             text: Binding<String>,
+                             suffix: String,
+                             accessibility: String) -> some View {
+        HStack {
+            Text(title)
+            Spacer()
+            TextField("0", text: text)
+                .keyboardType(.numberPad)
+                .multilineTextAlignment(.trailing)
+                .frame(maxWidth: 100)
+                .accessibilityLabel(accessibility)
+            Text(suffix)
+                .foregroundColor(.secondary)
+        }
+    }
+}

--- a/DroppedTests/UserDataTests.swift
+++ b/DroppedTests/UserDataTests.swift
@@ -118,11 +118,19 @@ final class UserDataTests: XCTestCase {
         )
 
         WorkoutManager.shared.saveWorkout(workout)
+        WorkoutManager.shared.saveLog(WorkoutLog(
+            workoutID: workout.id,
+            completedAt: Date(),
+            perceivedExertion: 6,
+            userDataSnapshot: UserData.defaultData
+        ))
 
         XCTAssertEqual(WorkoutManager.shared.loadWorkouts(), [workout], "Saved workouts should load from persisted storage")
+        XCTAssertFalse(WorkoutManager.shared.loadLogs().isEmpty, "Log fixture should persist before reset")
 
         WorkoutManager.shared.resetWorkouts()
 
         XCTAssertTrue(WorkoutManager.shared.loadWorkouts().isEmpty, "Reset should clear persisted workouts")
+        XCTAssertTrue(WorkoutManager.shared.loadLogs().isEmpty, "Reset should also clear persisted logs")
     }
 }

--- a/DroppedTests/WorkoutLogTests.swift
+++ b/DroppedTests/WorkoutLogTests.swift
@@ -1,0 +1,220 @@
+//
+//  WorkoutLogTests.swift
+//  DroppedTests
+//
+//  Unit tests covering the `WorkoutLog` model, its derived metrics, and the
+//  `WorkoutManager` log persistence APIs.
+//
+
+import XCTest
+@testable import Dropped
+
+final class WorkoutLogTests: XCTestCase {
+    override func setUpWithError() throws {
+        UserDataManager.shared.resetUserData()
+        WorkoutManager.shared.resetWorkouts()
+    }
+
+    override func tearDownWithError() throws {
+        UserDataManager.shared.resetUserData()
+        WorkoutManager.shared.resetWorkouts()
+    }
+
+    // MARK: - Model
+
+    func testRPEIsClampedIntoSupportedRange() {
+        let snapshot = UserData.defaultData
+
+        let low = WorkoutLog(workoutID: UUID(), completedAt: Date(),
+                             perceivedExertion: -3, userDataSnapshot: snapshot)
+        XCTAssertEqual(low.perceivedExertion, WorkoutLog.rpeRange.lowerBound,
+                       "RPE values below 1 should clamp to 1")
+
+        let high = WorkoutLog(workoutID: UUID(), completedAt: Date(),
+                              perceivedExertion: 42, userDataSnapshot: snapshot)
+        XCTAssertEqual(high.perceivedExertion, WorkoutLog.rpeRange.upperBound,
+                       "RPE values above 10 should clamp to 10")
+
+        let valid = WorkoutLog(workoutID: UUID(), completedAt: Date(),
+                               perceivedExertion: 7, userDataSnapshot: snapshot)
+        XCTAssertEqual(valid.perceivedExertion, 7,
+                       "Valid RPE values should be preserved")
+    }
+
+    func testNotesAreNormalized() {
+        let snapshot = UserData.defaultData
+
+        let blank = WorkoutLog(workoutID: UUID(), completedAt: Date(),
+                               perceivedExertion: 5, notes: "   \n  ",
+                               userDataSnapshot: snapshot)
+        XCTAssertNil(blank.notes,
+                     "Whitespace-only notes should normalize to nil")
+
+        let trimmed = WorkoutLog(workoutID: UUID(), completedAt: Date(),
+                                 perceivedExertion: 5, notes: "  felt great  ",
+                                 userDataSnapshot: snapshot)
+        XCTAssertEqual(trimmed.notes, "felt great",
+                       "Notes should have surrounding whitespace stripped")
+    }
+
+    func testEffectiveDurationFallsBackToPlanned() {
+        let snapshot = UserData.defaultData
+        let planned: TimeInterval = 60 * 60
+
+        let withoutOverride = WorkoutLog(workoutID: UUID(), completedAt: Date(),
+                                         perceivedExertion: 5,
+                                         userDataSnapshot: snapshot)
+        XCTAssertEqual(withoutOverride.effectiveDuration(planned: planned), planned)
+
+        let withOverride = WorkoutLog(workoutID: UUID(), completedAt: Date(),
+                                      perceivedExertion: 5,
+                                      durationOverride: 30 * 60,
+                                      userDataSnapshot: snapshot)
+        XCTAssertEqual(withOverride.effectiveDuration(planned: planned), 30 * 60,
+                       "Override should win over the planned duration")
+    }
+
+    func testIntensityFactorAndEstimatedTSS() {
+        let snapshot = UserData(
+            weight: 70.0,
+            weightUnit: WeightUnit.kilograms.rawValue,
+            ftp: 200,
+            trainingHoursPerWeek: 6,
+            trainingGoal: TrainingGoal.getFaster.rawValue
+        )
+
+        // 200 W avg @ 200 W FTP for 1h → IF=1.0, TSS=100
+        let log = WorkoutLog(
+            workoutID: UUID(),
+            completedAt: Date(),
+            perceivedExertion: 8,
+            averagePower: 200,
+            durationOverride: 60 * 60,
+            userDataSnapshot: snapshot
+        )
+        XCTAssertEqual(log.intensityFactor ?? 0, 1.0, accuracy: 0.0001)
+        XCTAssertEqual(log.estimatedTSS(planned: 0) ?? 0, 100.0, accuracy: 0.0001)
+
+        // Without average power IF + TSS are unknown.
+        let bare = WorkoutLog(workoutID: UUID(), completedAt: Date(),
+                              perceivedExertion: 5, userDataSnapshot: snapshot)
+        XCTAssertNil(bare.intensityFactor)
+        XCTAssertNil(bare.estimatedTSS(planned: 60 * 60))
+    }
+
+    func testIntensityFactorIsNilWhenFTPIsZero() {
+        let snapshot = UserData(weight: 70, weightUnit: WeightUnit.kilograms.rawValue,
+                                ftp: 0, trainingHoursPerWeek: 4,
+                                trainingGoal: TrainingGoal.haveFun.rawValue)
+        let log = WorkoutLog(workoutID: UUID(), completedAt: Date(),
+                             perceivedExertion: 6, averagePower: 180,
+                             userDataSnapshot: snapshot)
+        XCTAssertNil(log.intensityFactor,
+                     "IF must be nil when FTP is zero to avoid divide-by-zero")
+    }
+
+    func testCodableRoundTrip() throws {
+        let original = WorkoutLog(
+            workoutID: UUID(),
+            completedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            perceivedExertion: 7,
+            averagePower: 215,
+            averageHeartRate: 152,
+            durationOverride: 55 * 60,
+            notes: "Tough but good",
+            userDataSnapshot: UserData.defaultData
+        )
+
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(WorkoutLog.self, from: data)
+
+        XCTAssertEqual(decoded, original,
+                       "WorkoutLog should survive a JSON round trip unchanged")
+    }
+
+    // MARK: - Persistence
+
+    func testSaveLoadAndLookupByWorkoutID() {
+        let workoutID = UUID()
+        let log = WorkoutLog(workoutID: workoutID, completedAt: Date(),
+                             perceivedExertion: 6,
+                             userDataSnapshot: UserData.defaultData)
+
+        WorkoutManager.shared.saveLog(log)
+
+        XCTAssertEqual(WorkoutManager.shared.loadLogs(), [log])
+        XCTAssertEqual(WorkoutManager.shared.log(forWorkoutID: workoutID), log)
+        XCTAssertNil(WorkoutManager.shared.log(forWorkoutID: UUID()),
+                     "Unknown workout IDs should return nil")
+    }
+
+    func testSavingTwiceWithSameIDUpdatesInPlace() {
+        let logID = UUID()
+        let workoutID = UUID()
+        let initial = WorkoutLog(id: logID, workoutID: workoutID, completedAt: Date(),
+                                 perceivedExertion: 4,
+                                 userDataSnapshot: UserData.defaultData)
+        WorkoutManager.shared.saveLog(initial)
+
+        let updated = WorkoutLog(id: logID, workoutID: workoutID, completedAt: Date(),
+                                 perceivedExertion: 9, notes: "Harder than expected",
+                                 userDataSnapshot: UserData.defaultData)
+        WorkoutManager.shared.saveLog(updated)
+
+        let logs = WorkoutManager.shared.loadLogs()
+        XCTAssertEqual(logs.count, 1, "Re-saving the same log id should not create a duplicate")
+        XCTAssertEqual(logs.first?.perceivedExertion, 9)
+        XCTAssertEqual(logs.first?.notes, "Harder than expected")
+    }
+
+    func testLogLookupReturnsMostRecentWhenMultipleExist() {
+        let workoutID = UUID()
+        let earlier = WorkoutLog(
+            workoutID: workoutID,
+            completedAt: Date(timeIntervalSince1970: 1_000_000),
+            perceivedExertion: 3,
+            userDataSnapshot: UserData.defaultData
+        )
+        let later = WorkoutLog(
+            workoutID: workoutID,
+            completedAt: Date(timeIntervalSince1970: 2_000_000),
+            perceivedExertion: 8,
+            userDataSnapshot: UserData.defaultData
+        )
+        WorkoutManager.shared.saveLog(earlier)
+        WorkoutManager.shared.saveLog(later)
+
+        XCTAssertEqual(WorkoutManager.shared.log(forWorkoutID: workoutID), later,
+                       "Lookup should return the most recent log per workout")
+    }
+
+    func testDeleteLogRemovesAllLogsForWorkout() {
+        let workoutID = UUID()
+        let other = UUID()
+
+        WorkoutManager.shared.saveLog(WorkoutLog(workoutID: workoutID, completedAt: Date(),
+                                                  perceivedExertion: 5,
+                                                  userDataSnapshot: UserData.defaultData))
+        WorkoutManager.shared.saveLog(WorkoutLog(workoutID: other, completedAt: Date(),
+                                                  perceivedExertion: 6,
+                                                  userDataSnapshot: UserData.defaultData))
+
+        WorkoutManager.shared.deleteLog(forWorkoutID: workoutID)
+
+        XCTAssertNil(WorkoutManager.shared.log(forWorkoutID: workoutID))
+        XCTAssertNotNil(WorkoutManager.shared.log(forWorkoutID: other),
+                        "Unrelated logs should be untouched")
+    }
+
+    func testResetClearsLogs() {
+        WorkoutManager.shared.saveLog(WorkoutLog(workoutID: UUID(), completedAt: Date(),
+                                                  perceivedExertion: 5,
+                                                  userDataSnapshot: UserData.defaultData))
+        XCTAssertFalse(WorkoutManager.shared.loadLogs().isEmpty)
+
+        WorkoutManager.shared.resetWorkouts()
+
+        XCTAssertTrue(WorkoutManager.shared.loadLogs().isEmpty,
+                      "resetWorkouts should also clear persisted logs")
+    }
+}

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -24,24 +24,27 @@ This project is a SwiftUI-based iOS cycling training application.
 
 #### Dropped/Models/
 
-- **UserData.swift**: Core user, workout, interval, and workout-day models. Also contains persisted `UserDataManager` and `WorkoutManager` storage helpers.
+- **UserData.swift**: Core user, workout, interval, and workout-day models. Also contains persisted `UserDataManager` and `WorkoutManager` storage helpers (workouts, workout days, and completion logs).
 - **WorkoutType.swift**: Enum defining AI workout types: endurance, threshold, VO2 max, sprint, and recovery.
 - **AIWorkoutGenerator.swift**: OpenAI chat-completions client for generated workouts. Reads API keys from configuration, requests a strict JSON schema, and converts responses into `Workout` models.
+- **WorkoutLog.swift**: Persisted record of a completed workout (RPE, optional avg power / HR / duration override, notes, plus a `UserData` snapshot). Exposes derived `effectiveDuration`, `intensityFactor`, and `estimatedTSS` for future TSS / charts / streak surfaces.
 
 #### Dropped/ViewModels/
 
 - **OnboardingViewModel.swift**: Onboarding validation, unit conversion, and profile-save logic.
 - **WorkoutGeneratorViewModel.swift**: AI workout generator state, loading/error handling, and generated-workout acceptance into persisted workout storage.
+- **WorkoutLogViewModel.swift**: Form-state owner for the workout-completion sheet. Validates RPE, manages optional metric toggles, and bridges save / delete to `WorkoutManager`.
 
 #### Dropped/Views/
 
 - **InfoPopupView.swift**: Informational modal used for onboarding help.
 - **OnboardingView.swift**: Rider profile setup screen.
-- **PlanSummaryView.swift**: Training plan summary, generated workout cards, settings entry point, and onboarding reset.
+- **PlanSummaryView.swift**: Training plan summary, generated workout cards (with completion badges), settings entry point, and onboarding reset.
 - **SettingsView.swift**: Settings screen for preferred weight units and app information.
-- **WorkoutDetailView.swift**: Detailed workout screen with overview, interval list, and inline power/time graph.
+- **WorkoutDetailView.swift**: Detailed workout screen with overview, completion summary, interval list, inline power/time graph, and the "Mark Complete" / "Edit Log" CTA.
 - **WorkoutGeneratorView.swift**: AI workout type selection and generation screen.
 - **WorkoutGeneratorReviewView.swift**: Review surface for accepting or regenerating an AI-generated workout.
+- **WorkoutLogSheet.swift**: Modal form for logging a completed workout — RPE, optional avg power / HR / duration override, notes, and "Remove Log" when editing.
 
 ### Dropped.xcodeproj/
 
@@ -51,7 +54,8 @@ This project is a SwiftUI-based iOS cycling training application.
 ### DroppedTests/
 
 - **OnboardingViewModelTests.swift**: Unit tests for onboarding validation, unit conversion, and user-data saving.
-- **UserDataTests.swift**: Unit tests for unit conversion, user-data persistence, onboarding completion, and workout persistence reset behavior.
+- **UserDataTests.swift**: Unit tests for unit conversion, user-data persistence, onboarding completion, and workout/log persistence reset behavior.
+- **WorkoutLogTests.swift**: Unit tests for the `WorkoutLog` model (RPE clamping, notes normalization, derived IF/TSS) and the `WorkoutManager` log persistence APIs.
 
 ### DroppedUITests/
 


### PR DESCRIPTION
Riders can view their plan but have no way to record what actually happened in a session. Without persisted completion data we can't build adaptation, streaks, charts, or TSS later. This PR lays the foundation by letting riders mark each workout complete and capture how it went, with a data model that's ready to power those future surfaces.

## Approach

Introduces a dedicated `WorkoutLog` value type rather than mutating `Workout`. Workouts stay the immutable plan; logs are the actuals, keyed back via `workoutID`. Each log snapshots the rider's `UserData` at completion time so derived metrics like Intensity Factor and TSS can be recomputed accurately later, even after FTP changes.

`WorkoutLog` already exposes `effectiveDuration(planned:)`, `intensityFactor`, and `estimatedTSS(planned:)` so future charts/streaks/adaptation can plug in without a model migration. Nothing in the UI surfaces TSS yet by design — it's reserved for a later PR.

Persistence reuses the existing `UserDefaults`-backed `WorkoutManager` pattern under a new `com.dropped.workoutLogs` key. `resetWorkouts()` now clears logs too, so the existing "Restart Onboarding" flow keeps a clean slate.

## UX

- `WorkoutDetailView` gets a "Mark Complete" CTA at the bottom. Once logged, it flips to "Edit Log" and a green completion summary card appears at the top with date, RPE, and any captured metrics.
- The log sheet collects RPE on a 1–10 slider (required), optional avg power / avg HR / duration override, freeform notes, and an editable completion date so past sessions can be back-logged. Editing exposes a destructive "Remove Log" button to un-complete a session.
- `WorkoutCard` on the plan summary shows a green "RPE n" badge for completed sessions.

## Notes for review

- One log per workout for now; the manager API is keyed by `workoutID` (not log id) so we can relax that to multi-completion later without changing call sites.
- RPE is clamped into 1...10 in the model initializer, so persisted data can never go out of range even if a future caller forgets.
- Notes are normalized: whitespace-only entries persist as `nil` to keep the summary card clean.
- Future-dated workouts can still be marked complete — riders shift schedules and we shouldn't gate that.

## Tests

New `WorkoutLogTests` cover RPE clamping, notes normalization, codable round-trip, IF and TSS math (including FTP=0 safety), save/load/lookup/delete, most-recent-wins lookup when multiple logs exist for the same workout, and that `resetWorkouts` also clears logs. The existing `UserDataTests` reset test was extended to assert log cleanup as well.

Per repo rules, I did not build/run the simulator.