### PR TITLE
Add FTP test workouts and Coggan power zones

### DIFF
--- a/Dropped/ContentView.swift
+++ b/Dropped/ContentView.swift
@@ -17,6 +17,12 @@ struct ContentView: View {
                     NavigationLink(destination: PlanSummaryView(hasCompletedOnboarding: $hasCompletedOnboarding)) {
                         Label("Training Plan", systemImage: "calendar.badge.clock")
                     }
+                    NavigationLink(destination: FTPTestsView()) {
+                        Label("FTP Tests", systemImage: "bolt.heart")
+                    }
+                    NavigationLink(destination: PowerZonesView()) {
+                        Label("Power Zones", systemImage: "chart.bar.fill")
+                    }
                     NavigationLink(destination: {
                         // Inject dependencies for the generator
                         let userData = UserDataManager.shared.loadUserData()

--- a/Dropped/Models/FTPTest.swift
+++ b/Dropped/Models/FTPTest.swift
@@ -1,0 +1,131 @@
+//
+//  FTPTest.swift
+//  Dropped
+//
+
+import Foundation
+
+/// Built-in FTP test protocols.
+enum FTPTestType: String, CaseIterable, Identifiable, Codable {
+    case twentyMinute = "twentyMinute"
+    case ramp = "ramp"
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .twentyMinute: return "20-Minute FTP Test"
+        case .ramp: return "Ramp FTP Test"
+        }
+    }
+
+    var shortName: String {
+        switch self {
+        case .twentyMinute: return "20-Min Test"
+        case .ramp: return "Ramp Test"
+        }
+    }
+
+    var summary: String {
+        switch self {
+        case .twentyMinute:
+            return "Warm up, then ride as hard as you can sustain for 20 minutes. Your FTP is 95% of your average power."
+        case .ramp:
+            return "Step up power every minute until you can no longer hold the target. Your FTP is 75% of the last fully completed minute's power."
+        }
+    }
+
+    var resultPrompt: String {
+        switch self {
+        case .twentyMinute: return "Average power for the 20-minute effort"
+        case .ramp: return "Power of the last fully completed 1-minute step"
+        }
+    }
+}
+
+/// Pure FTP-from-test calculations.
+enum FTPCalculator {
+    /// FTP from a 20-minute average power: `round(avg * 0.95)`.
+    /// Returns 0 for non-positive input.
+    static func ftp(fromTwentyMinuteAvgWatts watts: Int) -> Int {
+        guard watts > 0 else { return 0 }
+        return Int(round(Double(watts) * 0.95))
+    }
+
+    /// FTP from a ramp test final completed minute: `round(final * 0.75)`.
+    /// Returns 0 for non-positive input.
+    static func ftp(fromRampFinalMinuteWatts watts: Int) -> Int {
+        guard watts > 0 else { return 0 }
+        return Int(round(Double(watts) * 0.75))
+    }
+
+    /// Convenience dispatch.
+    static func ftp(forTest test: FTPTestType, inputWatts: Int) -> Int {
+        switch test {
+        case .twentyMinute: return ftp(fromTwentyMinuteAvgWatts: inputWatts)
+        case .ramp: return ftp(fromRampFinalMinuteWatts: inputWatts)
+        }
+    }
+}
+
+/// Factory for built-in FTP-test `Workout` instances. These are real workouts
+/// that flow through the existing `WorkoutManager` and `WorkoutDetailView`, but
+/// are tagged via `Workout.testKind` so the UI can offer a "Log result" action.
+enum FTPTestWorkouts {
+    /// Build a 20-minute FTP test workout. Total ≈ 45 minutes:
+    /// 15 min warmup → 20 min effort at ~95% FTP target → 10 min cool-down.
+    static func twentyMinute(ftp: Int, date: Date = Date()) -> Workout {
+        let warmupWatts = max(1, Int(Double(ftp) * 0.55))
+        let effortWatts = max(1, Int(Double(ftp) * 0.95))
+        let cooldownWatts = max(1, Int(Double(ftp) * 0.45))
+
+        let intervals: [Interval] = [
+            Interval(watts: warmupWatts, duration: 15 * 60),
+            Interval(watts: effortWatts, duration: 20 * 60),
+            Interval(watts: cooldownWatts, duration: 10 * 60)
+        ]
+
+        return Workout(
+            title: FTPTestType.twentyMinute.displayName,
+            date: date,
+            summary: FTPTestType.twentyMinute.summary,
+            intervals: intervals,
+            status: .scheduled,
+            testKind: FTPTestType.twentyMinute.rawValue
+        )
+    }
+
+    /// Build a ramp test workout. 5-minute warmup at ~50% FTP, then 1-minute
+    /// steps starting at ~50% FTP and increasing 25 W per minute for 20 steps.
+    static func ramp(ftp: Int, date: Date = Date()) -> Workout {
+        let warmupWatts = max(1, Int(Double(ftp) * 0.50))
+        var intervals: [Interval] = [
+            Interval(watts: warmupWatts, duration: 5 * 60)
+        ]
+
+        let startWatts = max(50, Int(Double(ftp) * 0.50))
+        let stepWatts = 25
+        let stepCount = 20
+
+        for step in 0..<stepCount {
+            let watts = startWatts + step * stepWatts
+            intervals.append(Interval(watts: watts, duration: 60))
+        }
+
+        return Workout(
+            title: FTPTestType.ramp.displayName,
+            date: date,
+            summary: FTPTestType.ramp.summary,
+            intervals: intervals,
+            status: .scheduled,
+            testKind: FTPTestType.ramp.rawValue
+        )
+    }
+
+    static func workout(for test: FTPTestType, ftp: Int, date: Date = Date()) -> Workout {
+        switch test {
+        case .twentyMinute: return twentyMinute(ftp: ftp, date: date)
+        case .ramp: return ramp(ftp: ftp, date: date)
+        }
+    }
+}

--- a/Dropped/Models/PowerZones.swift
+++ b/Dropped/Models/PowerZones.swift
@@ -1,0 +1,140 @@
+//
+//  PowerZones.swift
+//  Dropped
+//
+
+import Foundation
+import SwiftUI
+
+/// Coggan-style cycling power training zones, derived from FTP.
+///
+/// Boundary policy: lower bound inclusive, upper bound inclusive (integer %FTP).
+/// Z1 covers 0–55%, Z7 is anything above 150%. This guarantees every integer
+/// %FTP maps to exactly one zone with no gaps or overlaps.
+enum PowerZone: Int, CaseIterable, Identifiable, Codable {
+    case z1 = 1
+    case z2
+    case z3
+    case z4
+    case z5
+    case z6
+    case z7
+
+    var id: Int { rawValue }
+
+    var name: String {
+        switch self {
+        case .z1: return "Active Recovery"
+        case .z2: return "Endurance"
+        case .z3: return "Tempo"
+        case .z4: return "Threshold"
+        case .z5: return "VO2 Max"
+        case .z6: return "Anaerobic"
+        case .z7: return "Neuromuscular"
+        }
+    }
+
+    var shortLabel: String {
+        switch self {
+        case .z1: return "Z1"
+        case .z2: return "Z2"
+        case .z3: return "Z3"
+        case .z4: return "Z4"
+        case .z5: return "Z5"
+        case .z6: return "Z6"
+        case .z7: return "Z7"
+        }
+    }
+
+    /// Percentage-of-FTP bounds (integers, both inclusive). Use `Int.max`
+    /// for Z7's open-ended upper bound.
+    var percentRange: ClosedRange<Int> {
+        switch self {
+        case .z1: return 0...55
+        case .z2: return 56...75
+        case .z3: return 76...90
+        case .z4: return 91...105
+        case .z5: return 106...120
+        case .z6: return 121...150
+        case .z7: return 151...Int.max
+        }
+    }
+
+    /// Human-readable %FTP range, e.g. "56–75%" or ">150%".
+    var percentRangeDescription: String {
+        switch self {
+        case .z7: return ">150%"
+        case .z1: return "<55%"
+        default:
+            let r = percentRange
+            return "\(r.lowerBound)–\(r.upperBound)%"
+        }
+    }
+
+    var color: Color {
+        switch self {
+        case .z1: return .blue
+        case .z2: return .green
+        case .z3: return .yellow
+        case .z4: return .orange
+        case .z5: return .red
+        case .z6: return .purple
+        case .z7: return .pink
+        }
+    }
+
+    /// Which zone an integer percentage of FTP falls in. Negative values clamp to Z1.
+    static func zone(forPercentFTP percent: Int) -> PowerZone {
+        let p = max(0, percent)
+        for zone in PowerZone.allCases where zone.percentRange.contains(p) {
+            return zone
+        }
+        return .z7
+    }
+}
+
+/// Watt ranges for each Coggan power zone, computed from the rider's FTP.
+struct PowerZones: Equatable {
+    let ftp: Int
+
+    init(ftp: Int) {
+        self.ftp = max(0, ftp)
+    }
+
+    /// Watt range for a given zone. For FTP=0, every range collapses to 0...0.
+    /// Z7's upper bound is `Int.max` to represent "no ceiling".
+    func range(for zone: PowerZone) -> ClosedRange<Int> {
+        guard ftp > 0 else { return 0...0 }
+        let pct = zone.percentRange
+        let lower = wattValue(forPercent: pct.lowerBound)
+        if zone == .z7 {
+            return lower...Int.max
+        }
+        let upper = wattValue(forPercent: pct.upperBound)
+        return lower...max(lower, upper)
+    }
+
+    /// Human-readable watt range, e.g. "112–150 W" or ">301 W".
+    func wattRangeDescription(for zone: PowerZone) -> String {
+        guard ftp > 0 else { return "—" }
+        let r = range(for: zone)
+        if zone == .z7 {
+            return ">\(r.lowerBound) W"
+        }
+        return "\(r.lowerBound)–\(r.upperBound) W"
+    }
+
+    /// All zones in ascending order.
+    var all: [PowerZone] { PowerZone.allCases }
+
+    /// Determine which zone a given wattage falls into for this FTP.
+    func zone(forWatts watts: Int) -> PowerZone {
+        guard ftp > 0 else { return .z1 }
+        let percent = Int((Double(watts) / Double(ftp)) * 100.0)
+        return PowerZone.zone(forPercentFTP: percent)
+    }
+
+    private func wattValue(forPercent percent: Int) -> Int {
+        Int(round(Double(ftp) * Double(percent) / 100.0))
+    }
+}

--- a/Dropped/Models/UserData.swift
+++ b/Dropped/Models/UserData.swift
@@ -50,14 +50,19 @@ struct Workout: Identifiable, Codable, Equatable {
     let summary: String
     let intervals: [Interval]
     let status: WorkoutStatus
-    
+    /// Optional marker identifying this workout as a built-in test (e.g. an FTP test).
+    /// Stored as the raw value of `FTPTestType` when applicable, nil otherwise.
+    /// Decoded with `decodeIfPresent` so older persisted workouts remain readable.
+    let testKind: String?
+
     init(
         id: UUID = UUID(),
         title: String,
         date: Date,
         summary: String,
         intervals: [Interval],
-        status: WorkoutStatus = .scheduled
+        status: WorkoutStatus = .scheduled,
+        testKind: String? = nil
     ) {
         self.id = id
         self.title = title
@@ -65,6 +70,22 @@ struct Workout: Identifiable, Codable, Equatable {
         self.summary = summary
         self.intervals = intervals
         self.status = status
+        self.testKind = testKind
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id, title, date, summary, intervals, status, testKind
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(UUID.self, forKey: .id)
+        self.title = try container.decode(String.self, forKey: .title)
+        self.date = try container.decode(Date.self, forKey: .date)
+        self.summary = try container.decode(String.self, forKey: .summary)
+        self.intervals = try container.decode([Interval].self, forKey: .intervals)
+        self.status = try container.decode(WorkoutStatus.self, forKey: .status)
+        self.testKind = try container.decodeIfPresent(String.self, forKey: .testKind)
     }
     
     /// Calculate the total duration of the workout in seconds
@@ -151,6 +172,9 @@ struct UserData: Codable, Equatable {
         }
         return weight
     }
+
+    /// Coggan power zones derived from the user's current FTP.
+    var powerZones: PowerZones { PowerZones(ftp: ftp) }
 }
 
 // MARK: - Integrated Models
@@ -190,10 +214,12 @@ class UserDataManager {
     private let onboardingCompletedKey = "com.dropped.hasCompletedOnboarding"
     private let defaults: UserDefaults
     
-    private init(defaults: UserDefaults = .standard) {
+    /// Internal so tests can construct an isolated instance backed by an
+    /// in-memory `UserDefaults(suiteName:)`. Production code should use `.shared`.
+    init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
     }
-    
+
     func saveUserData(_ userData: UserData) {
         guard let data = try? JSONEncoder().encode(userData) else {
             assertionFailure("Failed to encode user data.")
@@ -230,10 +256,11 @@ class WorkoutManager {
     private let workoutDaysKey = "com.dropped.workoutDays"
     private let defaults: UserDefaults
     
-    private init(defaults: UserDefaults = .standard) {
+    /// Internal so tests can construct an isolated instance.
+    init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
     }
-    
+
     // MARK: - Workout Management
     
     /// Save a workout to memory

--- a/Dropped/ViewModels/FTPTestResultViewModel.swift
+++ b/Dropped/ViewModels/FTPTestResultViewModel.swift
@@ -1,0 +1,92 @@
+//
+//  FTPTestResultViewModel.swift
+//  Dropped
+//
+
+import Foundation
+import SwiftUI
+
+/// Drives the post-test result entry flow: takes the rider's raw input,
+/// computes a new FTP, and on confirm persists the updated profile and
+/// marks the source workout completed.
+@MainActor
+final class FTPTestResultViewModel: ObservableObject {
+    @Published var inputWatts: String = ""
+    @Published var inputError: String? = nil
+
+    let testType: FTPTestType
+    let sourceWorkout: Workout?
+    let previousFTP: Int
+
+    private let userDataManager: UserDataManager
+    private let workoutManager: WorkoutManager
+
+    init(
+        testType: FTPTestType,
+        sourceWorkout: Workout? = nil,
+        userDataManager: UserDataManager = .shared,
+        workoutManager: WorkoutManager = .shared
+    ) {
+        self.testType = testType
+        self.sourceWorkout = sourceWorkout
+        self.userDataManager = userDataManager
+        self.workoutManager = workoutManager
+        self.previousFTP = userDataManager.loadUserData().ftp
+    }
+
+    /// Parsed watt input, or nil if invalid.
+    var parsedWatts: Int? {
+        guard let value = Int(inputWatts.trimmingCharacters(in: .whitespaces)),
+              value > 0 else { return nil }
+        return value
+    }
+
+    /// New FTP given the current input, or nil when input is invalid.
+    var newFTP: Int? {
+        guard let watts = parsedWatts else { return nil }
+        return FTPCalculator.ftp(forTest: testType, inputWatts: watts)
+    }
+
+    /// FTP delta vs. the previous value (positive = improvement). Nil when no valid input.
+    var delta: Int? {
+        guard let new = newFTP else { return nil }
+        return new - previousFTP
+    }
+
+    var canConfirm: Bool { newFTP != nil }
+
+    func validate() {
+        if parsedWatts == nil {
+            inputError = "Enter a positive whole number of watts."
+        } else {
+            inputError = nil
+        }
+    }
+
+    /// Persist the new FTP into the user profile and, if applicable, mark the
+    /// source workout completed. Returns the new FTP on success.
+    @discardableResult
+    func confirm() -> Int? {
+        validate()
+        guard let new = newFTP else { return nil }
+
+        var current = userDataManager.loadUserData()
+        current.ftp = new
+        userDataManager.saveUserData(current)
+
+        if let source = sourceWorkout {
+            let completed = Workout(
+                id: source.id,
+                title: source.title,
+                date: source.date,
+                summary: source.summary,
+                intervals: source.intervals,
+                status: .completed,
+                testKind: source.testKind
+            )
+            workoutManager.saveWorkout(completed)
+        }
+
+        return new
+    }
+}

--- a/Dropped/Views/FTPTestsView.swift
+++ b/Dropped/Views/FTPTestsView.swift
@@ -1,0 +1,237 @@
+//
+//  FTPTestsView.swift
+//  Dropped
+//
+
+import SwiftUI
+
+/// Lists the built-in FTP test protocols. Tapping a test saves it as a
+/// scheduled `Workout` for today and navigates into the existing detail view.
+struct FTPTestsView: View {
+    @State private var startedWorkout: Workout?
+    @State private var navigateToWorkout = false
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                Text("Pick a protocol, complete the workout, then log your result. We'll compute your new FTP and update your power zones.")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                    .padding(.horizontal)
+
+                ForEach(FTPTestType.allCases) { test in
+                    FTPTestCard(test: test) {
+                        startTest(test)
+                    }
+                }
+
+                Spacer(minLength: 24)
+            }
+            .padding(.vertical)
+        }
+        .navigationTitle("FTP Tests")
+        .navigationBarTitleDisplayMode(.inline)
+        .background(
+            Group {
+                if let workout = startedWorkout {
+                    NavigationLink(
+                        destination: WorkoutDetailView(workout: workout),
+                        isActive: $navigateToWorkout,
+                        label: { EmptyView() }
+                    )
+                    .hidden()
+                }
+            }
+        )
+    }
+
+    private func startTest(_ test: FTPTestType) {
+        let userData = UserDataManager.shared.loadUserData()
+        let workout = FTPTestWorkouts.workout(for: test, ftp: userData.ftp)
+        WorkoutManager.shared.saveWorkout(workout)
+        startedWorkout = workout
+        navigateToWorkout = true
+    }
+}
+
+private struct FTPTestCard: View {
+    let test: FTPTestType
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack {
+                    Image(systemName: test == .twentyMinute ? "stopwatch" : "chart.line.uptrend.xyaxis")
+                        .font(.title3)
+                        .foregroundColor(.accentColor)
+                    Text(test.displayName)
+                        .font(.headline)
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .foregroundColor(.secondary)
+                }
+
+                Text(test.summary)
+                    .font(.body)
+                    .foregroundColor(.primary)
+                    .multilineTextAlignment(.leading)
+            }
+            .padding()
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(Color(.systemBackground))
+                    .shadow(color: Color.black.opacity(0.1), radius: 3, x: 0, y: 1)
+            )
+            .padding(.horizontal)
+        }
+        .buttonStyle(PlainButtonStyle())
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(test.displayName). \(test.summary)")
+        .accessibilityHint("Starts the test workout")
+    }
+}
+
+/// Result entry sheet after completing an FTP test. Lets the rider input the
+/// key number, previews the new FTP and zones, and persists on confirm.
+struct FTPTestResultEntryView: View {
+    @StateObject var viewModel: FTPTestResultViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    init(testType: FTPTestType, sourceWorkout: Workout? = nil) {
+        _viewModel = StateObject(
+            wrappedValue: FTPTestResultViewModel(
+                testType: testType,
+                sourceWorkout: sourceWorkout
+            )
+        )
+    }
+
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text(viewModel.testType.displayName)
+                            .font(.title2)
+                            .fontWeight(.bold)
+                        Text(viewModel.testType.summary)
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                    }
+
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text(viewModel.testType.resultPrompt)
+                            .font(.headline)
+                        HStack {
+                            TextField("Watts", text: $viewModel.inputWatts)
+                                .keyboardType(.numberPad)
+                                .padding()
+                                .background(
+                                    RoundedRectangle(cornerRadius: 10)
+                                        .stroke(viewModel.inputError != nil ? Color.red : Color.gray.opacity(0.3), lineWidth: 1)
+                                )
+                                .accessibilityIdentifier("ftpResultWattsField")
+                                .onChange(of: viewModel.inputWatts) { _, _ in viewModel.validate() }
+                            Text("W")
+                                .foregroundColor(.secondary)
+                        }
+                        if let error = viewModel.inputError {
+                            Text(error)
+                                .font(.caption)
+                                .foregroundColor(.red)
+                        }
+                    }
+
+                    beforeAfterCard
+
+                    Button(action: confirm) {
+                        Text("Update FTP")
+                            .font(.headline)
+                            .foregroundColor(.white)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 14)
+                            .background((viewModel.canConfirm ? Color.accentColor : Color.gray).gradient)
+                            .cornerRadius(12)
+                    }
+                    .disabled(!viewModel.canConfirm)
+                    .accessibilityIdentifier("ftpResultConfirmButton")
+
+                    Spacer(minLength: 12)
+                }
+                .padding()
+            }
+            .navigationTitle("Log Result")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+        }
+    }
+
+    private var beforeAfterCard: some View {
+        let new = viewModel.newFTP
+        let delta = viewModel.delta
+        return VStack(alignment: .leading, spacing: 10) {
+            Text("Result Preview")
+                .font(.headline)
+
+            HStack {
+                VStack(alignment: .leading) {
+                    Text("Previous")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    Text("\(viewModel.previousFTP) W")
+                        .font(.title3)
+                        .fontWeight(.bold)
+                }
+                Spacer()
+                Image(systemName: "arrow.right")
+                    .foregroundColor(.secondary)
+                Spacer()
+                VStack(alignment: .trailing) {
+                    Text("New")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    Text(new.map { "\($0) W" } ?? "—")
+                        .font(.title3)
+                        .fontWeight(.bold)
+                        .foregroundColor(deltaColor(delta))
+                }
+            }
+
+            if let d = delta, new != nil {
+                Text(deltaDescription(d))
+                    .font(.subheadline)
+                    .foregroundColor(deltaColor(d))
+            }
+        }
+        .padding()
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color(.systemGray6))
+        )
+    }
+
+    private func deltaColor(_ delta: Int?) -> Color {
+        guard let d = delta else { return .primary }
+        if d > 0 { return .green }
+        if d < 0 { return .orange }
+        return .primary
+    }
+
+    private func deltaDescription(_ d: Int) -> String {
+        if d > 0 { return "+\(d) W vs. previous" }
+        if d < 0 { return "\(d) W vs. previous" }
+        return "No change"
+    }
+
+    private func confirm() {
+        if viewModel.confirm() != nil {
+            dismiss()
+        }
+    }
+}

--- a/Dropped/Views/OnboardingView.swift
+++ b/Dropped/Views/OnboardingView.swift
@@ -63,7 +63,7 @@ struct OnboardingView: View {
                         .overlay {
                             InfoPopupView(
                                 title: "What is FTP?",
-                                message: "Functional Threshold Power (FTP) is the maximum power you can sustain for an hour. It's used to set your training zones and personalize your workouts.\n\nIf you don't know your FTP, enter an estimate based on your fitness level:\n• Beginner: 120-150 watts\n• Intermediate: 150-220 watts\n• Advanced: 220+ watts",
+                                message: "Functional Threshold Power (FTP) is the maximum power you can sustain for an hour. It's used to set your training zones and personalize your workouts.\n\nIf you don't know your FTP, enter an estimate based on your fitness level:\n• Beginner: 120-150 watts\n• Intermediate: 150-220 watts\n• Advanced: 220+ watts\n\nAfter setup, you can take a 20-minute or Ramp FTP test from the FTP Tests screen to dial in an accurate value.",
                                 isPresented: $showingFTPInfo
                             )
                         }

--- a/Dropped/Views/PlanSummaryView.swift
+++ b/Dropped/Views/PlanSummaryView.swift
@@ -51,6 +51,57 @@ struct PlanSummaryView: View {
                             .shadow(color: Color.black.opacity(0.1), radius: 5, x: 0, y: 2)
                     )
                     .padding(.horizontal)
+
+                    // Power zones + FTP test entry points
+                    VStack(alignment: .leading, spacing: 10) {
+                        NavigationLink(destination: PowerZonesView()) {
+                            HStack {
+                                Image(systemName: "chart.bar.fill")
+                                    .foregroundColor(.accentColor)
+                                VStack(alignment: .leading) {
+                                    Text("Power Zones")
+                                        .font(.headline)
+                                        .foregroundColor(.primary)
+                                    Text("See your Z1–Z7 wattage targets")
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
+                                }
+                                Spacer()
+                                Image(systemName: "chevron.right")
+                                    .foregroundColor(.secondary)
+                            }
+                            .padding()
+                            .background(
+                                RoundedRectangle(cornerRadius: 12)
+                                    .fill(Color(.systemBackground))
+                                    .shadow(color: Color.black.opacity(0.08), radius: 4, x: 0, y: 2)
+                            )
+                        }
+                        NavigationLink(destination: FTPTestsView()) {
+                            HStack {
+                                Image(systemName: "bolt.heart")
+                                    .foregroundColor(.accentColor)
+                                VStack(alignment: .leading) {
+                                    Text("Take an FTP test")
+                                        .font(.headline)
+                                        .foregroundColor(.primary)
+                                    Text("20-minute or Ramp protocol")
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
+                                }
+                                Spacer()
+                                Image(systemName: "chevron.right")
+                                    .foregroundColor(.secondary)
+                            }
+                            .padding()
+                            .background(
+                                RoundedRectangle(cornerRadius: 12)
+                                    .fill(Color(.systemBackground))
+                                    .shadow(color: Color.black.opacity(0.08), radius: 4, x: 0, y: 2)
+                            )
+                        }
+                    }
+                    .padding(.horizontal)
                     
                     // Workout plan
                     VStack(alignment: .leading, spacing: 10) {

--- a/Dropped/Views/PowerZonesView.swift
+++ b/Dropped/Views/PowerZonesView.swift
@@ -1,0 +1,119 @@
+//
+//  PowerZonesView.swift
+//  Dropped
+//
+
+import SwiftUI
+
+/// Displays Coggan power zones (Z1–Z7) with %FTP ranges and target wattages
+/// for the rider's current FTP.
+struct PowerZonesView: View {
+    @State private var userData: UserData = UserDataManager.shared.loadUserData()
+
+    private var zones: PowerZones { userData.powerZones }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                headerCard
+
+                VStack(spacing: 10) {
+                    ForEach(zones.all) { zone in
+                        PowerZoneRow(
+                            zone: zone,
+                            wattRange: zones.wattRangeDescription(for: zone)
+                        )
+                    }
+                }
+                .padding(.horizontal)
+
+                NavigationLink(destination: FTPTestsView()) {
+                    HStack {
+                        Image(systemName: "bolt.heart")
+                        Text("Take an FTP test")
+                            .fontWeight(.semibold)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 12)
+                    .foregroundColor(.white)
+                    .background(Color.accentColor.gradient)
+                    .cornerRadius(12)
+                }
+                .padding(.horizontal)
+                .padding(.top, 8)
+
+                Spacer(minLength: 24)
+            }
+            .padding(.top)
+        }
+        .navigationTitle("Power Zones")
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            userData = UserDataManager.shared.loadUserData()
+        }
+    }
+
+    private var headerCard: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Current FTP")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+            Text("\(userData.ftp) W")
+                .font(.largeTitle)
+                .fontWeight(.bold)
+            Text("Zones use Coggan's classic seven-zone model.")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color(.systemBackground))
+                .shadow(color: Color.black.opacity(0.08), radius: 4, x: 0, y: 2)
+        )
+        .padding(.horizontal)
+    }
+}
+
+private struct PowerZoneRow: View {
+    let zone: PowerZone
+    let wattRange: String
+
+    var body: some View {
+        HStack(spacing: 12) {
+            RoundedRectangle(cornerRadius: 4)
+                .fill(zone.color)
+                .frame(width: 6, height: 44)
+
+            VStack(alignment: .leading, spacing: 2) {
+                HStack {
+                    Text(zone.shortLabel)
+                        .font(.subheadline)
+                        .fontWeight(.bold)
+                        .foregroundColor(.secondary)
+                    Text(zone.name)
+                        .font(.headline)
+                }
+                Text(zone.percentRangeDescription)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            Spacer()
+
+            Text(wattRange)
+                .font(.subheadline)
+                .fontWeight(.semibold)
+                .monospacedDigit()
+        }
+        .padding(.vertical, 10)
+        .padding(.horizontal, 12)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(Color(.systemGray6))
+        )
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(zone.shortLabel) \(zone.name), \(zone.percentRangeDescription) of FTP, \(wattRange)")
+    }
+}

--- a/Dropped/Views/SettingsView.swift
+++ b/Dropped/Views/SettingsView.swift
@@ -121,6 +121,16 @@ struct SettingsView: View {
                     .padding(.vertical, 8)
                 }
                 
+                // Training Section
+                Section(header: Text("Training")) {
+                    NavigationLink(destination: PowerZonesView()) {
+                        Label("Power Zones", systemImage: "chart.bar.fill")
+                    }
+                    NavigationLink(destination: FTPTestsView()) {
+                        Label("Take an FTP test", systemImage: "bolt.heart")
+                    }
+                }
+
                 // About Section
                 Section(header: Text("About")) {
                     HStack {

--- a/Dropped/Views/WorkoutDetailView.swift
+++ b/Dropped/Views/WorkoutDetailView.swift
@@ -5,10 +5,16 @@ struct WorkoutDetailView: View {
     /// The workout to display.
     let workout: Workout
 
+    @State private var showingResultEntry = false
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 24) {
                 WorkoutOverviewHeader(workout: workout)
+                if let testTypeRaw = workout.testKind,
+                   let testType = FTPTestType(rawValue: testTypeRaw) {
+                    logResultButton(testType: testType)
+                }
                 intervalsSection
                 powerProfileSection
             }
@@ -17,6 +23,28 @@ struct WorkoutDetailView: View {
         .background(Color(UIColor.systemBackground))
         .navigationTitle("Workout Details")
         .navigationBarTitleDisplayMode(.inline)
+        .sheet(isPresented: $showingResultEntry) {
+            if let testTypeRaw = workout.testKind,
+               let testType = FTPTestType(rawValue: testTypeRaw) {
+                FTPTestResultEntryView(testType: testType, sourceWorkout: workout)
+            }
+        }
+    }
+
+    private func logResultButton(testType: FTPTestType) -> some View {
+        Button(action: { showingResultEntry = true }) {
+            HStack {
+                Image(systemName: "square.and.pencil")
+                Text("Log \(testType.shortName) result")
+                    .fontWeight(.semibold)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 12)
+            .foregroundColor(.white)
+            .background(Color.accentColor.gradient)
+            .cornerRadius(12)
+        }
+        .accessibilityIdentifier("logFTPTestResultButton")
     }
 
     /// List of workout intervals, or an empty state if the workout has none.

--- a/DroppedTests/FTPCalculatorTests.swift
+++ b/DroppedTests/FTPCalculatorTests.swift
@@ -1,0 +1,57 @@
+//
+//  FTPCalculatorTests.swift
+//  DroppedTests
+//
+
+import XCTest
+@testable import Dropped
+
+final class FTPCalculatorTests: XCTestCase {
+    func testTwentyMinuteFormula() {
+        // 250 W avg → 250 * 0.95 = 237.5 → rounds to 238
+        XCTAssertEqual(FTPCalculator.ftp(fromTwentyMinuteAvgWatts: 250), 238)
+        // 300 W avg → 285
+        XCTAssertEqual(FTPCalculator.ftp(fromTwentyMinuteAvgWatts: 300), 285)
+        // 200 W avg → 190
+        XCTAssertEqual(FTPCalculator.ftp(fromTwentyMinuteAvgWatts: 200), 190)
+    }
+
+    func testTwentyMinuteRoundingBoundary() {
+        // 211 * 0.95 = 200.45 → 200
+        XCTAssertEqual(FTPCalculator.ftp(fromTwentyMinuteAvgWatts: 211), 200)
+        // 212 * 0.95 = 201.4 → 201
+        XCTAssertEqual(FTPCalculator.ftp(fromTwentyMinuteAvgWatts: 212), 201)
+    }
+
+    func testRampFormula() {
+        // 300 W final → 225
+        XCTAssertEqual(FTPCalculator.ftp(fromRampFinalMinuteWatts: 300), 225)
+        // 400 W final → 300
+        XCTAssertEqual(FTPCalculator.ftp(fromRampFinalMinuteWatts: 400), 300)
+    }
+
+    func testRampRoundingBoundary() {
+        // 267 * 0.75 = 200.25 → 200
+        XCTAssertEqual(FTPCalculator.ftp(fromRampFinalMinuteWatts: 267), 200)
+        // 268 * 0.75 = 201 → 201
+        XCTAssertEqual(FTPCalculator.ftp(fromRampFinalMinuteWatts: 268), 201)
+    }
+
+    func testNonPositiveInputsReturnZero() {
+        XCTAssertEqual(FTPCalculator.ftp(fromTwentyMinuteAvgWatts: 0), 0)
+        XCTAssertEqual(FTPCalculator.ftp(fromTwentyMinuteAvgWatts: -50), 0)
+        XCTAssertEqual(FTPCalculator.ftp(fromRampFinalMinuteWatts: 0), 0)
+        XCTAssertEqual(FTPCalculator.ftp(fromRampFinalMinuteWatts: -10), 0)
+    }
+
+    func testDispatchByTestType() {
+        XCTAssertEqual(
+            FTPCalculator.ftp(forTest: .twentyMinute, inputWatts: 250),
+            FTPCalculator.ftp(fromTwentyMinuteAvgWatts: 250)
+        )
+        XCTAssertEqual(
+            FTPCalculator.ftp(forTest: .ramp, inputWatts: 300),
+            FTPCalculator.ftp(fromRampFinalMinuteWatts: 300)
+        )
+    }
+}

--- a/DroppedTests/FTPTestResultViewModelTests.swift
+++ b/DroppedTests/FTPTestResultViewModelTests.swift
@@ -1,0 +1,144 @@
+//
+//  FTPTestResultViewModelTests.swift
+//  DroppedTests
+//
+
+import XCTest
+@testable import Dropped
+
+@MainActor
+final class FTPTestResultViewModelTests: XCTestCase {
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+    private var userManager: UserDataManager!
+    private var workoutManager: WorkoutManager!
+
+    override func setUpWithError() throws {
+        suiteName = "FTPTestResultVMTests-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+        defaults.removePersistentDomain(forName: suiteName)
+        userManager = UserDataManager(defaults: defaults)
+        workoutManager = WorkoutManager(defaults: defaults)
+
+        // Seed a known starting profile.
+        userManager.saveUserData(UserData(
+            weight: 70,
+            weightUnit: WeightUnit.kilograms.rawValue,
+            ftp: 200,
+            trainingHoursPerWeek: 5,
+            trainingGoal: TrainingGoal.haveFun.rawValue
+        ))
+    }
+
+    override func tearDownWithError() throws {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        userManager = nil
+        workoutManager = nil
+    }
+
+    func testInitialStateUsesPersistedFTP() {
+        let vm = FTPTestResultViewModel(
+            testType: .twentyMinute,
+            userDataManager: userManager,
+            workoutManager: workoutManager
+        )
+        XCTAssertEqual(vm.previousFTP, 200)
+        XCTAssertNil(vm.newFTP)
+        XCTAssertFalse(vm.canConfirm)
+    }
+
+    func testTwentyMinuteConfirmUpdatesProfile() {
+        let vm = FTPTestResultViewModel(
+            testType: .twentyMinute,
+            userDataManager: userManager,
+            workoutManager: workoutManager
+        )
+        vm.inputWatts = "250"
+        XCTAssertEqual(vm.newFTP, 238)
+        XCTAssertEqual(vm.delta, 38)
+        XCTAssertTrue(vm.canConfirm)
+
+        let result = vm.confirm()
+        XCTAssertEqual(result, 238)
+        XCTAssertEqual(userManager.loadUserData().ftp, 238)
+    }
+
+    func testRampConfirmUpdatesProfile() {
+        let vm = FTPTestResultViewModel(
+            testType: .ramp,
+            userDataManager: userManager,
+            workoutManager: workoutManager
+        )
+        vm.inputWatts = "300"
+        XCTAssertEqual(vm.newFTP, 225)
+        XCTAssertEqual(vm.delta, 25)
+
+        XCTAssertEqual(vm.confirm(), 225)
+        XCTAssertEqual(userManager.loadUserData().ftp, 225)
+    }
+
+    func testInvalidInputBlocksConfirm() {
+        let vm = FTPTestResultViewModel(
+            testType: .twentyMinute,
+            userDataManager: userManager,
+            workoutManager: workoutManager
+        )
+        vm.inputWatts = "not a number"
+        XCTAssertNil(vm.newFTP)
+        XCTAssertFalse(vm.canConfirm)
+        XCTAssertNil(vm.confirm())
+        XCTAssertNotNil(vm.inputError)
+        // FTP must remain unchanged.
+        XCTAssertEqual(userManager.loadUserData().ftp, 200)
+    }
+
+    func testZeroInputIsRejected() {
+        let vm = FTPTestResultViewModel(
+            testType: .twentyMinute,
+            userDataManager: userManager,
+            workoutManager: workoutManager
+        )
+        vm.inputWatts = "0"
+        XCTAssertNil(vm.newFTP)
+        XCTAssertNil(vm.confirm())
+        XCTAssertEqual(userManager.loadUserData().ftp, 200)
+    }
+
+    func testConfirmMarksSourceWorkoutCompleted() {
+        let workout = FTPTestWorkouts.twentyMinute(ftp: 200)
+        workoutManager.saveWorkout(workout)
+
+        let vm = FTPTestResultViewModel(
+            testType: .twentyMinute,
+            sourceWorkout: workout,
+            userDataManager: userManager,
+            workoutManager: workoutManager
+        )
+        vm.inputWatts = "250"
+        _ = vm.confirm()
+
+        let stored = workoutManager.loadWorkouts().first { $0.id == workout.id }
+        XCTAssertNotNil(stored)
+        XCTAssertEqual(stored?.status, .completed)
+        XCTAssertEqual(stored?.testKind, FTPTestType.twentyMinute.rawValue)
+    }
+
+    func testConfirmDoesNotChangeOtherProfileFields() {
+        let original = userManager.loadUserData()
+        let vm = FTPTestResultViewModel(
+            testType: .twentyMinute,
+            userDataManager: userManager,
+            workoutManager: workoutManager
+        )
+        vm.inputWatts = "250"
+        _ = vm.confirm()
+
+        let updated = userManager.loadUserData()
+        XCTAssertEqual(updated.weight, original.weight)
+        XCTAssertEqual(updated.weightUnit, original.weightUnit)
+        XCTAssertEqual(updated.trainingHoursPerWeek, original.trainingHoursPerWeek)
+        XCTAssertEqual(updated.trainingGoal, original.trainingGoal)
+        XCTAssertNotEqual(updated.ftp, original.ftp)
+    }
+}

--- a/DroppedTests/FTPTestWorkoutsTests.swift
+++ b/DroppedTests/FTPTestWorkoutsTests.swift
@@ -1,0 +1,85 @@
+//
+//  FTPTestWorkoutsTests.swift
+//  DroppedTests
+//
+
+import XCTest
+@testable import Dropped
+
+final class FTPTestWorkoutsTests: XCTestCase {
+    func testTwentyMinuteWorkoutShape() {
+        let workout = FTPTestWorkouts.twentyMinute(ftp: 200)
+
+        XCTAssertEqual(workout.testKind, FTPTestType.twentyMinute.rawValue)
+        XCTAssertEqual(workout.intervals.count, 3)
+        XCTAssertEqual(workout.totalDuration, TimeInterval((15 + 20 + 10) * 60))
+
+        // Effort interval at ~95% FTP
+        let effort = workout.intervals[1]
+        XCTAssertEqual(effort.duration, TimeInterval(20 * 60))
+        XCTAssertEqual(effort.watts, Int(Double(200) * 0.95))
+
+        // Warmup is the first interval and easier than effort
+        XCTAssertLessThan(workout.intervals[0].watts, effort.watts)
+        // Cooldown last and easier than warmup or equal
+        XCTAssertLessThanOrEqual(workout.intervals[2].watts, workout.intervals[0].watts)
+    }
+
+    func testRampWorkoutShape() {
+        let workout = FTPTestWorkouts.ramp(ftp: 200)
+
+        XCTAssertEqual(workout.testKind, FTPTestType.ramp.rawValue)
+        // 5-min warmup + 20 one-minute steps
+        XCTAssertEqual(workout.intervals.count, 21)
+        XCTAssertEqual(workout.intervals.first?.duration, TimeInterval(5 * 60))
+
+        // Each step is 1 minute
+        for step in workout.intervals.dropFirst() {
+            XCTAssertEqual(step.duration, 60)
+        }
+
+        // Steps strictly ascending
+        let steps = Array(workout.intervals.dropFirst())
+        for i in 1..<steps.count {
+            XCTAssertGreaterThan(steps[i].watts, steps[i - 1].watts)
+        }
+
+        // Step delta is 25 W
+        XCTAssertEqual(steps[1].watts - steps[0].watts, 25)
+    }
+
+    func testWorkoutFactoryDispatch() {
+        let twenty = FTPTestWorkouts.workout(for: .twentyMinute, ftp: 220)
+        XCTAssertEqual(twenty.testKind, FTPTestType.twentyMinute.rawValue)
+
+        let ramp = FTPTestWorkouts.workout(for: .ramp, ftp: 220)
+        XCTAssertEqual(ramp.testKind, FTPTestType.ramp.rawValue)
+    }
+
+    func testWorkoutCodableBackwardCompatWithoutTestKind() throws {
+        // Simulate an older persisted workout JSON (no testKind field).
+        let legacyJSON = """
+        {
+            "id": "11111111-1111-1111-1111-111111111111",
+            "title": "Legacy",
+            "date": 0,
+            "summary": "old",
+            "intervals": [],
+            "status": "Scheduled"
+        }
+        """.data(using: .utf8)!
+
+        let decoder = JSONDecoder()
+        let workout = try decoder.decode(Workout.self, from: legacyJSON)
+        XCTAssertNil(workout.testKind)
+        XCTAssertEqual(workout.title, "Legacy")
+    }
+
+    func testWorkoutCodableRoundTripWithTestKind() throws {
+        let original = FTPTestWorkouts.twentyMinute(ftp: 250)
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(Workout.self, from: data)
+        XCTAssertEqual(decoded, original)
+        XCTAssertEqual(decoded.testKind, FTPTestType.twentyMinute.rawValue)
+    }
+}

--- a/DroppedTests/PowerZonesTests.swift
+++ b/DroppedTests/PowerZonesTests.swift
@@ -1,0 +1,102 @@
+//
+//  PowerZonesTests.swift
+//  DroppedTests
+//
+
+import XCTest
+@testable import Dropped
+
+final class PowerZonesTests: XCTestCase {
+    func testZoneBoundariesByPercent() {
+        // Z1 boundary
+        XCTAssertEqual(PowerZone.zone(forPercentFTP: 0), .z1)
+        XCTAssertEqual(PowerZone.zone(forPercentFTP: 55), .z1)
+        XCTAssertEqual(PowerZone.zone(forPercentFTP: 56), .z2)
+        // Z2/Z3
+        XCTAssertEqual(PowerZone.zone(forPercentFTP: 75), .z2)
+        XCTAssertEqual(PowerZone.zone(forPercentFTP: 76), .z3)
+        // Z3/Z4
+        XCTAssertEqual(PowerZone.zone(forPercentFTP: 90), .z3)
+        XCTAssertEqual(PowerZone.zone(forPercentFTP: 91), .z4)
+        // Z4/Z5
+        XCTAssertEqual(PowerZone.zone(forPercentFTP: 105), .z4)
+        XCTAssertEqual(PowerZone.zone(forPercentFTP: 106), .z5)
+        // Z5/Z6
+        XCTAssertEqual(PowerZone.zone(forPercentFTP: 120), .z5)
+        XCTAssertEqual(PowerZone.zone(forPercentFTP: 121), .z6)
+        // Z6/Z7
+        XCTAssertEqual(PowerZone.zone(forPercentFTP: 150), .z6)
+        XCTAssertEqual(PowerZone.zone(forPercentFTP: 151), .z7)
+        XCTAssertEqual(PowerZone.zone(forPercentFTP: 1000), .z7)
+        // Negative clamps to Z1
+        XCTAssertEqual(PowerZone.zone(forPercentFTP: -10), .z1)
+    }
+
+    func testWattRangesForFTP200() {
+        let zones = PowerZones(ftp: 200)
+        // Z1: 0–55% of 200 = 0–110
+        XCTAssertEqual(zones.range(for: .z1), 0...110)
+        // Z2: 56–75% = 112–150
+        XCTAssertEqual(zones.range(for: .z2), 112...150)
+        // Z3: 76–90% = 152–180
+        XCTAssertEqual(zones.range(for: .z3), 152...180)
+        // Z4: 91–105% = 182–210
+        XCTAssertEqual(zones.range(for: .z4), 182...210)
+        // Z5: 106–120% = 212–240
+        XCTAssertEqual(zones.range(for: .z5), 212...240)
+        // Z6: 121–150% = 242–300
+        XCTAssertEqual(zones.range(for: .z6), 242...300)
+        // Z7: 151%+ = 302...Int.max
+        XCTAssertEqual(zones.range(for: .z7).lowerBound, 302)
+        XCTAssertEqual(zones.range(for: .z7).upperBound, Int.max)
+    }
+
+    func testZoneForWattsAtFTP200() {
+        let zones = PowerZones(ftp: 200)
+        // 100 W = 50% → Z1
+        XCTAssertEqual(zones.zone(forWatts: 100), .z1)
+        // 150 W = 75% → Z2
+        XCTAssertEqual(zones.zone(forWatts: 150), .z2)
+        // 180 W = 90% → Z3
+        XCTAssertEqual(zones.zone(forWatts: 180), .z3)
+        // 200 W = 100% → Z4
+        XCTAssertEqual(zones.zone(forWatts: 200), .z4)
+        // 240 W = 120% → Z5
+        XCTAssertEqual(zones.zone(forWatts: 240), .z5)
+        // 300 W = 150% → Z6
+        XCTAssertEqual(zones.zone(forWatts: 300), .z6)
+        // 320 W = 160% → Z7
+        XCTAssertEqual(zones.zone(forWatts: 320), .z7)
+    }
+
+    func testFTPZeroIsDegenerateButSafe() {
+        let zones = PowerZones(ftp: 0)
+        for zone in zones.all {
+            XCTAssertEqual(zones.range(for: zone), 0...0)
+        }
+        XCTAssertEqual(zones.zone(forWatts: 500), .z1)
+    }
+
+    func testNegativeFTPClampsToZero() {
+        let zones = PowerZones(ftp: -100)
+        XCTAssertEqual(zones.ftp, 0)
+    }
+
+    func testAllOrderingAndCount() {
+        let zones = PowerZones(ftp: 250)
+        XCTAssertEqual(zones.all, [.z1, .z2, .z3, .z4, .z5, .z6, .z7])
+        XCTAssertEqual(zones.all.count, 7)
+    }
+
+    func testUserDataExposesPowerZones() {
+        let user = UserData(
+            weight: 70,
+            weightUnit: WeightUnit.kilograms.rawValue,
+            ftp: 250,
+            trainingHoursPerWeek: 5,
+            trainingGoal: TrainingGoal.haveFun.rawValue
+        )
+        XCTAssertEqual(user.powerZones.ftp, 250)
+        XCTAssertEqual(user.powerZones.range(for: .z4).lowerBound, Int(round(250 * 0.91)))
+    }
+}

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -24,14 +24,17 @@ This project is a SwiftUI-based iOS cycling training application.
 
 #### Dropped/Models/
 
-- **UserData.swift**: Core user, workout, interval, and workout-day models. Also contains persisted `UserDataManager` and `WorkoutManager` storage helpers.
+- **UserData.swift**: Core user, workout, interval, and workout-day models. Also contains persisted `UserDataManager` and `WorkoutManager` storage helpers. `Workout` carries an optional `testKind` marker (back-compat decoded) for built-in tests; `UserData` exposes a computed `powerZones` property.
 - **WorkoutType.swift**: Enum defining AI workout types: endurance, threshold, VO2 max, sprint, and recovery.
 - **AIWorkoutGenerator.swift**: OpenAI chat-completions client for generated workouts. Reads API keys from configuration, requests a strict JSON schema, and converts responses into `Workout` models.
+- **PowerZones.swift**: `PowerZone` enum (Coggan Z1–Z7 with %FTP bounds, names, colors) and `PowerZones` struct that maps an FTP value to per-zone watt ranges.
+- **FTPTest.swift**: `FTPTestType` enum (`.twentyMinute`, `.ramp`), `FTPCalculator` (FTP from 20-min avg or ramp final-minute power), and `FTPTestWorkouts` factory that builds standard `Workout` instances for each protocol.
 
 #### Dropped/ViewModels/
 
 - **OnboardingViewModel.swift**: Onboarding validation, unit conversion, and profile-save logic.
 - **WorkoutGeneratorViewModel.swift**: AI workout generator state, loading/error handling, and generated-workout acceptance into persisted workout storage.
+- **FTPTestResultViewModel.swift**: Validates a rider's FTP-test result entry, computes the new FTP, and persists it via injected `UserDataManager`/`WorkoutManager` (also marks the source test workout completed).
 
 #### Dropped/Views/
 
@@ -42,6 +45,8 @@ This project is a SwiftUI-based iOS cycling training application.
 - **WorkoutDetailView.swift**: Detailed workout screen with overview, interval list, and inline power/time graph.
 - **WorkoutGeneratorView.swift**: AI workout type selection and generation screen.
 - **WorkoutGeneratorReviewView.swift**: Review surface for accepting or regenerating an AI-generated workout.
+- **PowerZonesView.swift**: Lists Coggan zones Z1–Z7 with %FTP ranges and target wattages computed from the rider's current FTP. Includes a link to the FTP tests screen.
+- **FTPTestsView.swift**: Lists built-in FTP test protocols (20-minute and Ramp), starts them as scheduled workouts, and provides `FTPTestResultEntryView` — the post-test result entry sheet that previews the new FTP and writes it to the user profile on confirm.
 
 ### Dropped.xcodeproj/
 
@@ -52,6 +57,10 @@ This project is a SwiftUI-based iOS cycling training application.
 
 - **OnboardingViewModelTests.swift**: Unit tests for onboarding validation, unit conversion, and user-data saving.
 - **UserDataTests.swift**: Unit tests for unit conversion, user-data persistence, onboarding completion, and workout persistence reset behavior.
+- **FTPCalculatorTests.swift**: Unit tests for FTP-from-test math (20-minute and ramp formulas, rounding boundaries, non-positive guards).
+- **PowerZonesTests.swift**: Unit tests for Coggan zone boundary classification, watt-range computation across FTPs (including FTP=0), and `UserData.powerZones`.
+- **FTPTestWorkoutsTests.swift**: Unit tests for the structure of built-in FTP test workouts and `Workout` codable backward compatibility for the new `testKind` field.
+- **FTPTestResultViewModelTests.swift**: Unit tests for the result-entry view model using isolated `UserDefaults`, covering profile updates, validation, and the source-workout completion side effect.
 
 ### DroppedUITests/
 


### PR DESCRIPTION
## Why

Riders had no in-app way to determine or update their FTP, and the app didn't expose Coggan power zones derived from FTP. This adds the two standard FTP test protocols, a guided result-entry flow that updates the persisted profile, and a dedicated Power Zones screen so riders can see what each wattage range means for them.

## What

- **Two built-in FTP test workouts.** A 20-minute test (FTP = `round(avg × 0.95)`) and a Ramp test (FTP = `round(final-minute × 0.75)`). Both are real `Workout` instances that flow through the existing `WorkoutManager` and `WorkoutDetailView`, surfaced from a new "FTP Tests" entry point in `ContentView`, `PlanSummaryView`, and `SettingsView`.
- **Post-test result entry.** From a test workout's detail screen, "Log result" opens a sheet that asks for the key number, previews before/after FTP plus delta, and on confirm writes the new FTP into the user profile and marks the source workout completed.
- **Coggan power zones (Z1–Z7).** New `PowerZone`/`PowerZones` model and `UserData.powerZones` computed property. Boundary policy is lower-and-upper-inclusive on integer %FTP so every value maps to exactly one zone (Z1 0–55, Z2 56–75, Z3 76–90, Z4 91–105, Z5 106–120, Z6 121–150, Z7 151+).
- **Power Zones screen.** New `PowerZonesView` lists each zone with name, %FTP range, and target wattages for the rider's current FTP. Linked from `PlanSummaryView`, `SettingsView` (new "Training" section), and `ContentView`.
- **Onboarding hint.** The existing FTP info popup now mentions taking a 20-minute or Ramp test after onboarding to dial in an accurate value.

## Notable design decisions

- **Workout test marker.** Added an optional `Workout.testKind: String?` rather than pattern-matching on titles, so the "Log result" button only appears on test workouts. Custom `init(from:)` uses `decodeIfPresent` so previously persisted workouts still decode cleanly; `encode(to:)` stays auto-synthesized so equality round-trips.
- **Manager testability.** `UserDataManager.init` and `WorkoutManager.init` are now internal so tests can construct isolated instances backed by `UserDefaults(suiteName:)`. Production code still uses `.shared`.
- **Scope discipline.** Did not add a pre-onboarding test path (would require profile-less storage). Instead enriched the existing FTP info popup.

## Tests

- `FTPCalculatorTests` — both formulas, rounding boundaries, non-positive guards.
- `PowerZonesTests` — zone classification at every boundary, watt ranges for FTP=200, degenerate FTP=0 behavior.
- `FTPTestWorkoutsTests` — interval shape for both protocols and `Workout` Codable backward compatibility.
- `FTPTestResultViewModelTests` — uses an isolated `UserDefaults` suite to verify FTP persistence, validation, and the source-workout completion side effect.

Build/run was intentionally not executed per session conventions.