### PR TITLE
Add in-app interval player

### DIFF
--- a/Dropped/Services/IntervalCueService.swift
+++ b/Dropped/Services/IntervalCueService.swift
@@ -1,0 +1,131 @@
+//
+//  IntervalCueService.swift
+//  Dropped
+//
+//  Translates `IntervalPlayerCueIntent` values from the interval player view
+//  model into audible + tactile feedback. Kept as a thin, side-effect-only
+//  wrapper so the view model itself can stay pure and testable.
+//
+//  Responsibilities:
+//    • Configure `AVAudioSession` for `.playback` so cues are heard with the
+//      ringer switch silenced (typical fitness-app behavior).
+//    • Play short system tones for countdown ticks and interval transitions.
+//    • Trigger `UIImpactFeedbackGenerator` haptics matching the cue weight.
+//    • Speak the next interval target via `AVSpeechSynthesizer` when a new
+//      interval begins.
+//
+
+import Foundation
+import AVFoundation
+import AudioToolbox
+import UIKit
+
+/// Plays audio + haptic feedback in response to interval player cue intents.
+@MainActor
+final class IntervalCueService {
+
+    // MARK: Inputs
+
+    /// The workout being played. Used to read interval watts when speaking a
+    /// "Next: X watts" cue.
+    private let workout: Workout
+
+    // MARK: Dependencies
+
+    private let synthesizer: AVSpeechSynthesizer
+    private let lightHaptic: UIImpactFeedbackGenerator
+    private let mediumHaptic: UIImpactFeedbackGenerator
+    private let heavyHaptic: UIImpactFeedbackGenerator
+    private let notificationHaptic: UINotificationFeedbackGenerator
+
+    // System sound IDs. We use built-in tones to avoid bundling assets.
+    private let countdownSoundID: SystemSoundID = 1057   // "Tink"
+    private let transitionSoundID: SystemSoundID = 1113  // "Begin Recording"
+    private let completionSoundID: SystemSoundID = 1025  // "Fanfare"
+
+    // MARK: Init
+
+    init(workout: Workout) {
+        self.workout = workout
+        self.synthesizer = AVSpeechSynthesizer()
+        self.lightHaptic = UIImpactFeedbackGenerator(style: .light)
+        self.mediumHaptic = UIImpactFeedbackGenerator(style: .medium)
+        self.heavyHaptic = UIImpactFeedbackGenerator(style: .heavy)
+        self.notificationHaptic = UINotificationFeedbackGenerator()
+    }
+
+    /// Configure the shared audio session for playback. Call once when the
+    /// player presents.
+    func activate() {
+        do {
+            let session = AVAudioSession.sharedInstance()
+            // `.playback` so cues are audible even when the silent switch is on.
+            // `.mixWithOthers` so we don't kill the rider's music.
+            try session.setCategory(.playback, mode: .spokenAudio, options: [.mixWithOthers, .duckOthers])
+            try session.setActive(true, options: [])
+        } catch {
+            // Audio is best-effort; haptics will still fire.
+            print("IntervalCueService: audio session activation failed: \(error)")
+        }
+        lightHaptic.prepare()
+        mediumHaptic.prepare()
+        heavyHaptic.prepare()
+        notificationHaptic.prepare()
+    }
+
+    /// Release the audio session. Call when the player dismisses.
+    func deactivate() {
+        synthesizer.stopSpeaking(at: .immediate)
+        try? AVAudioSession.sharedInstance().setActive(false, options: [.notifyOthersOnDeactivation])
+    }
+
+    /// Handle a single cue intent emitted by the view model.
+    func handle(_ intent: IntervalPlayerCueIntent) {
+        switch intent {
+        case .countdownTick:
+            AudioServicesPlaySystemSound(countdownSoundID)
+            lightHaptic.impactOccurred()
+            lightHaptic.prepare()
+
+        case .intervalEnded:
+            AudioServicesPlaySystemSound(transitionSoundID)
+            mediumHaptic.impactOccurred()
+            mediumHaptic.prepare()
+
+        case .intervalStarted(let index):
+            heavyHaptic.impactOccurred()
+            heavyHaptic.prepare()
+            speakStart(forIndex: index)
+
+        case .workoutCompleted:
+            AudioServicesPlaySystemSound(completionSoundID)
+            notificationHaptic.notificationOccurred(.success)
+            speak("Workout complete. Nice work.")
+        }
+    }
+
+    // MARK: Private helpers
+
+    private func speakStart(forIndex index: Int) {
+        guard workout.intervals.indices.contains(index) else { return }
+        let interval = workout.intervals[index]
+        let minutes = Int(interval.duration) / 60
+        let seconds = Int(interval.duration) % 60
+        let durationPhrase: String
+        if minutes > 0 && seconds > 0 {
+            durationPhrase = "\(minutes) minute\(minutes == 1 ? "" : "s") \(seconds) second\(seconds == 1 ? "" : "s")"
+        } else if minutes > 0 {
+            durationPhrase = "\(minutes) minute\(minutes == 1 ? "" : "s")"
+        } else {
+            durationPhrase = "\(seconds) second\(seconds == 1 ? "" : "s")"
+        }
+        speak("Next: \(interval.watts) watts for \(durationPhrase).")
+    }
+
+    private func speak(_ phrase: String) {
+        let utterance = AVSpeechUtterance(string: phrase)
+        utterance.rate = AVSpeechUtteranceDefaultSpeechRate
+        utterance.volume = 1.0
+        synthesizer.speak(utterance)
+    }
+}

--- a/Dropped/ViewModels/IntervalPlayerViewModel.swift
+++ b/Dropped/ViewModels/IntervalPlayerViewModel.swift
@@ -1,0 +1,316 @@
+//
+//  IntervalPlayerViewModel.swift
+//  Dropped
+//
+//  State machine and timing engine for the in-app interval player.
+//
+//  This view model is intentionally pure: it has no SwiftUI, AVFoundation, or UIKit
+//  dependencies. Time is read through an injectable `now` closure so unit tests can
+//  drive the timeline deterministically. Audio / haptic side effects are produced
+//  as `CueIntent` values handed to an injected `cueHandler` closure, keeping the
+//  view model fully testable without mocks.
+//
+
+import Foundation
+import Combine
+
+// MARK: - Cue intents
+
+/// A side-effect intent emitted by the player. The view layer (or a service) is
+/// responsible for translating intents into audio + haptic feedback.
+enum IntervalPlayerCueIntent: Equatable {
+    /// Final 3, 2, or 1 second tick before an interval ends. The associated value
+    /// is the seconds remaining (3, 2, or 1).
+    case countdownTick(secondsRemaining: Int)
+    /// An interval just began. Carries the index (zero-based) of the started interval.
+    case intervalStarted(index: Int)
+    /// An interval just finished naturally. Carries the index of the interval that ended.
+    case intervalEnded(index: Int)
+    /// The full workout finished naturally (last interval reached its duration).
+    case workoutCompleted
+}
+
+// MARK: - Player state
+
+/// High-level state of the player session.
+enum IntervalPlayerState: Equatable {
+    /// Not yet started, or just constructed.
+    case idle
+    /// Actively progressing through intervals.
+    case running
+    /// User paused; elapsed time is frozen.
+    case paused
+    /// Workout finished, either naturally or via end-early.
+    case finished
+}
+
+// MARK: - View model
+
+/// Drives the in-app interval player UI. Backed by a wall-clock anchor so the
+/// session remains accurate after backgrounding or screen sleep.
+///
+/// Threading: all mutating methods must be called on the main actor; published
+/// properties feed SwiftUI directly.
+@MainActor
+final class IntervalPlayerViewModel: ObservableObject {
+
+    // MARK: Inputs
+
+    /// The workout being played.
+    let workout: Workout
+
+    /// User FTP, used to display target power as a percentage of FTP. A value of
+    /// zero or negative disables the percentage readout.
+    let ftp: Int
+
+    // MARK: Published state
+
+    @Published private(set) var state: IntervalPlayerState = .idle
+    /// Index of the currently active interval. Always within
+    /// `0..<workout.intervals.count` while the player is running, paused, or
+    /// finished naturally; for an empty workout it stays at 0.
+    @Published private(set) var currentIndex: Int = 0
+    /// Elapsed time inside the current interval, in seconds. Clamped to
+    /// `[0, currentInterval.duration]`.
+    @Published private(set) var elapsedInInterval: TimeInterval = 0
+
+    // MARK: Dependencies
+
+    private let now: () -> Date
+    private let cueHandler: (IntervalPlayerCueIntent) -> Void
+
+    // MARK: Internal timing state
+
+    /// Wall-clock anchor for "when the current interval started". When the player
+    /// is paused this value is a sentinel; resume recomputes it from
+    /// `frozenElapsed` so backgrounded time does not bleed into the session.
+    private var intervalStartReference: Date = .distantPast
+    /// Snapshot of `elapsedInInterval` taken when paused, used to restore the
+    /// timeline on resume.
+    private var frozenElapsed: TimeInterval = 0
+    /// Last countdown second already emitted for the current interval. Prevents
+    /// duplicate haptic / audio cues when `tick()` runs faster than 1 Hz.
+    private var lastEmittedCountdownSecond: Int = 0
+    /// Tracks whether the natural completion cue has been emitted, so it fires at
+    /// most once per session.
+    private var didEmitCompletion: Bool = false
+
+    // MARK: Init
+
+    /// Creates a new view model.
+    ///
+    /// - Parameters:
+    ///   - workout: The workout to play.
+    ///   - ftp: User functional threshold power (watts). Pass 0 to hide %FTP.
+    ///   - now: Clock used for wall-clock arithmetic. Defaults to `Date.init`.
+    ///   - cueHandler: Receiver for audio/haptic intents. Defaults to a no-op,
+    ///     which makes the type trivially constructible from tests.
+    init(
+        workout: Workout,
+        ftp: Int,
+        now: @escaping () -> Date = Date.init,
+        cueHandler: @escaping (IntervalPlayerCueIntent) -> Void = { _ in }
+    ) {
+        self.workout = workout
+        self.ftp = ftp
+        self.now = now
+        self.cueHandler = cueHandler
+    }
+
+    // MARK: Derived values
+
+    /// The current interval, or `nil` for an empty workout / past-the-end index.
+    var currentInterval: Interval? {
+        guard workout.intervals.indices.contains(currentIndex) else { return nil }
+        return workout.intervals[currentIndex]
+    }
+
+    /// The next interval after the current one, or `nil` if this is the last.
+    var nextInterval: Interval? {
+        let nextIndex = currentIndex + 1
+        guard workout.intervals.indices.contains(nextIndex) else { return nil }
+        return workout.intervals[nextIndex]
+    }
+
+    /// Seconds remaining in the current interval. Zero when no interval is active.
+    var remainingInInterval: TimeInterval {
+        guard let interval = currentInterval else { return 0 }
+        return max(0, interval.duration - elapsedInInterval)
+    }
+
+    /// Total elapsed seconds across the entire workout, including completed
+    /// intervals plus the in-progress portion of the current one.
+    var overallElapsed: TimeInterval {
+        let completed = workout.intervals.prefix(currentIndex).reduce(0) { $0 + $1.duration }
+        return completed + min(elapsedInInterval, currentInterval?.duration ?? 0)
+    }
+
+    /// Seconds remaining across the entire workout.
+    var overallRemaining: TimeInterval {
+        max(0, workout.totalDuration - overallElapsed)
+    }
+
+    /// Overall progress in the range `[0, 1]`. Zero for an empty workout.
+    var progressFraction: Double {
+        let total = workout.totalDuration
+        guard total > 0 else { return 0 }
+        return min(1, max(0, overallElapsed / total))
+    }
+
+    /// Target watts for the current interval, or `nil` when no interval is active.
+    var currentTargetWatts: Int? {
+        currentInterval?.watts
+    }
+
+    /// Target as a percentage of FTP (e.g. `0.85` for 85% FTP). `nil` when FTP is
+    /// unset or no interval is active.
+    var currentPercentFTP: Double? {
+        guard ftp > 0, let watts = currentTargetWatts else { return nil }
+        return Double(watts) / Double(ftp)
+    }
+
+    // MARK: Lifecycle
+
+    /// Begins the workout from the first interval. No-op if already running, or
+    /// if the workout has no intervals.
+    func start() {
+        guard state == .idle else { return }
+        guard !workout.intervals.isEmpty else { return }
+        currentIndex = 0
+        elapsedInInterval = 0
+        intervalStartReference = now()
+        lastEmittedCountdownSecond = 0
+        didEmitCompletion = false
+        state = .running
+        cueHandler(.intervalStarted(index: 0))
+    }
+
+    /// Pauses the session. Elapsed time inside the current interval is frozen
+    /// until `resume()` is called.
+    func pause() {
+        guard state == .running else { return }
+        // Capture latest elapsed before freezing, so the UI matches what the
+        // user saw at the moment they tapped pause.
+        recomputeElapsed()
+        frozenElapsed = elapsedInInterval
+        state = .paused
+    }
+
+    /// Resumes a paused session. Re-anchors the wall clock so any time spent
+    /// paused (even across backgrounding) is excluded from the workout.
+    func resume() {
+        guard state == .paused else { return }
+        intervalStartReference = now().addingTimeInterval(-frozenElapsed)
+        state = .running
+        // Re-emit the most recent countdown if we're still inside the 3..1 window
+        // — but only for a second we have not yet announced for this interval.
+        tick()
+    }
+
+    /// Advances immediately to the next interval. If already on the last
+    /// interval, finishes the workout (without emitting `workoutCompleted`,
+    /// since the user manually skipped past it rather than completing it).
+    func skip() {
+        guard state == .running || state == .paused else { return }
+        let endingIndex = currentIndex
+        cueHandler(.intervalEnded(index: endingIndex))
+        let nextIndex = endingIndex + 1
+        if workout.intervals.indices.contains(nextIndex) {
+            currentIndex = nextIndex
+            elapsedInInterval = 0
+            frozenElapsed = 0
+            intervalStartReference = now()
+            lastEmittedCountdownSecond = 0
+            cueHandler(.intervalStarted(index: nextIndex))
+            if state == .paused {
+                // Stay paused at the start of the new interval.
+            }
+        } else {
+            finish(natural: false)
+        }
+    }
+
+    /// Ends the workout immediately at the user's request. Does not emit
+    /// `workoutCompleted` (that intent is reserved for natural completion).
+    func endEarly() {
+        guard state == .running || state == .paused else { return }
+        finish(natural: false)
+    }
+
+    /// Recomputes elapsed time from the wall clock and advances intervals as
+    /// needed. Call from a Timer publisher or on `scenePhase` resume. Safe to
+    /// call repeatedly; it is idempotent for a fixed `now()` value.
+    func tick() {
+        guard state == .running else { return }
+        advance()
+    }
+
+    // MARK: Private
+
+    /// Pulls the latest wall-clock reading into `elapsedInInterval` without
+    /// crossing interval boundaries (used for pause snapshot / countdown checks
+    /// inside the current interval).
+    private func recomputeElapsed() {
+        guard let interval = currentInterval else { return }
+        let raw = now().timeIntervalSince(intervalStartReference)
+        elapsedInInterval = min(max(0, raw), interval.duration)
+    }
+
+    /// Walk forward through any intervals that have completed since the last
+    /// tick, emitting end / start cues with carry-over so we don't drift even
+    /// after long background gaps.
+    private func advance() {
+        while state == .running, let interval = currentInterval {
+            let raw = now().timeIntervalSince(intervalStartReference)
+            if raw < interval.duration {
+                elapsedInInterval = max(0, raw)
+                emitCountdownIfNeeded(interval: interval)
+                return
+            }
+            // Interval boundary crossed.
+            cueHandler(.intervalEnded(index: currentIndex))
+            let overflow = raw - interval.duration
+            let nextIndex = currentIndex + 1
+            if workout.intervals.indices.contains(nextIndex) {
+                currentIndex = nextIndex
+                elapsedInInterval = 0
+                lastEmittedCountdownSecond = 0
+                // Carry overflow into the new interval so a slow tick doesn't
+                // lose time.
+                intervalStartReference = now().addingTimeInterval(-overflow)
+                cueHandler(.intervalStarted(index: nextIndex))
+            } else {
+                // Last interval finished naturally.
+                elapsedInInterval = interval.duration
+                finish(natural: true)
+                return
+            }
+        }
+    }
+
+    /// Emits a countdown cue when the remaining seconds (rounded up) enters the
+    /// 3..1 window for the first time within the current interval.
+    private func emitCountdownIfNeeded(interval: Interval) {
+        let remaining = interval.duration - elapsedInInterval
+        // Use ceil so we announce "3" while remaining is in (2, 3], etc.
+        let secondsLeft = Int(ceil(remaining))
+        guard (1...3).contains(secondsLeft) else { return }
+        guard secondsLeft != lastEmittedCountdownSecond else { return }
+        // Only count down when we are crossing each integer boundary, not when
+        // we resume mid-window with a smaller value than already announced.
+        if lastEmittedCountdownSecond == 0 || secondsLeft < lastEmittedCountdownSecond {
+            lastEmittedCountdownSecond = secondsLeft
+            cueHandler(.countdownTick(secondsRemaining: secondsLeft))
+        }
+    }
+
+    /// Finalize the session and, when reached naturally, emit the completion
+    /// cue exactly once.
+    private func finish(natural: Bool) {
+        state = .finished
+        if natural, !didEmitCompletion {
+            didEmitCompletion = true
+            cueHandler(.workoutCompleted)
+        }
+    }
+}

--- a/Dropped/Views/IntervalPlayerView.swift
+++ b/Dropped/Views/IntervalPlayerView.swift
@@ -1,0 +1,400 @@
+//
+//  IntervalPlayerView.swift
+//  Dropped
+//
+//  Full-screen guided workout player. Drives `IntervalPlayerViewModel` with a
+//  10 Hz timer, plays cues through `IntervalCueService`, and keeps the screen
+//  awake for the duration of the session.
+//
+//  This file owns only presentation; all timing/state logic lives in the view
+//  model so it can be unit-tested without UIKit.
+//
+
+import SwiftUI
+import UIKit
+
+/// Full-screen interval player presented from `WorkoutDetailView`.
+struct IntervalPlayerView: View {
+    let workout: Workout
+    let ftp: Int
+
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.scenePhase) private var scenePhase
+
+    @StateObject private var viewModel: IntervalPlayerViewModel
+    @State private var cueService: IntervalCueService
+    @State private var showEndConfirm: Bool = false
+
+    /// 10 Hz tick keeps the displayed seconds smooth without burning battery.
+    private let ticker = Timer.publish(every: 0.1, on: .main, in: .common).autoconnect()
+
+    init(workout: Workout, ftp: Int) {
+        self.workout = workout
+        self.ftp = ftp
+        let service = IntervalCueService(workout: workout)
+        _cueService = State(initialValue: service)
+        _viewModel = StateObject(wrappedValue: IntervalPlayerViewModel(
+            workout: workout,
+            ftp: ftp,
+            cueHandler: { [service] intent in service.handle(intent) }
+        ))
+    }
+
+    var body: some View {
+        ZStack {
+            backgroundGradient.ignoresSafeArea()
+
+            VStack(spacing: 24) {
+                topBar
+                Spacer(minLength: 8)
+                BigTargetBlock(
+                    watts: viewModel.currentTargetWatts,
+                    percentFTP: viewModel.currentPercentFTP,
+                    state: viewModel.state
+                )
+                IntervalTimerBlock(
+                    elapsed: viewModel.elapsedInInterval,
+                    remaining: viewModel.remainingInInterval,
+                    intervalIndex: viewModel.currentIndex,
+                    totalIntervals: workout.intervals.count
+                )
+                Spacer(minLength: 8)
+                NextIntervalPreview(next: viewModel.nextInterval, ftp: ftp)
+                OverallProgressBar(
+                    progress: viewModel.progressFraction,
+                    overallElapsed: viewModel.overallElapsed,
+                    overallRemaining: viewModel.overallRemaining
+                )
+                PlayerControlsBar(
+                    state: viewModel.state,
+                    onPauseResume: { togglePauseResume() },
+                    onSkip: { viewModel.skip() },
+                    onEnd: { showEndConfirm = true }
+                )
+            }
+            .padding(.horizontal, 24)
+            .padding(.vertical, 16)
+        }
+        .onAppear {
+            cueService.activate()
+            UIApplication.shared.isIdleTimerDisabled = true
+            viewModel.start()
+        }
+        .onDisappear {
+            UIApplication.shared.isIdleTimerDisabled = false
+            cueService.deactivate()
+        }
+        .onReceive(ticker) { _ in
+            viewModel.tick()
+        }
+        .onChange(of: scenePhase) { _, newValue in
+            if newValue == .active {
+                // Recompute immediately after returning from background so the
+                // UI doesn't show a stale frame for the next 100ms.
+                viewModel.tick()
+            }
+        }
+        .onChange(of: viewModel.state) { _, newValue in
+            if newValue == .finished {
+                // Brief delay so the completion cue is heard before dismissing.
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) {
+                    dismiss()
+                }
+            }
+        }
+        .confirmationDialog(
+            "End workout?",
+            isPresented: $showEndConfirm,
+            titleVisibility: .visible
+        ) {
+            Button("End workout", role: .destructive) {
+                viewModel.endEarly()
+            }
+            Button("Keep going", role: .cancel) {}
+        } message: {
+            Text("Your progress so far won't be saved.")
+        }
+    }
+
+    private var backgroundGradient: some View {
+        LinearGradient(
+            colors: [Color(.systemIndigo).opacity(0.85), Color.black],
+            startPoint: .top,
+            endPoint: .bottom
+        )
+    }
+
+    private var topBar: some View {
+        HStack {
+            Button {
+                if viewModel.state == .running {
+                    viewModel.pause()
+                }
+                showEndConfirm = true
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.headline)
+                    .padding(10)
+                    .background(Circle().fill(Color.white.opacity(0.15)))
+                    .foregroundColor(.white)
+            }
+            .accessibilityLabel("End workout")
+
+            Spacer()
+
+            Text(workout.title)
+                .font(.headline)
+                .foregroundColor(.white.opacity(0.9))
+                .lineLimit(1)
+
+            Spacer()
+
+            // Spacer to balance the X button visually.
+            Color.clear.frame(width: 44, height: 44)
+        }
+    }
+
+    private func togglePauseResume() {
+        switch viewModel.state {
+        case .running: viewModel.pause()
+        case .paused: viewModel.resume()
+        default: break
+        }
+    }
+}
+
+// MARK: - Subviews
+
+/// Big primary number showing the current target (watts + %FTP secondary).
+private struct BigTargetBlock: View {
+    let watts: Int?
+    let percentFTP: Double?
+    let state: IntervalPlayerState
+
+    var body: some View {
+        VStack(spacing: 4) {
+            Text("TARGET")
+                .font(.caption)
+                .tracking(2)
+                .foregroundColor(.white.opacity(0.6))
+            Text(watts.map { "\($0)" } ?? "—")
+                .font(.system(size: 96, weight: .heavy, design: .rounded))
+                .foregroundColor(.white)
+                .monospacedDigit()
+                .accessibilityLabel(watts.map { "Target \($0) watts" } ?? "No target")
+            Text("watts")
+                .font(.title3)
+                .foregroundColor(.white.opacity(0.8))
+            if let percentFTP {
+                Text(percentFTPText(percentFTP))
+                    .font(.headline)
+                    .foregroundColor(.white.opacity(0.85))
+                    .padding(.top, 2)
+                    .accessibilityLabel("\(Int((percentFTP * 100).rounded())) percent of F T P")
+            }
+            if state == .paused {
+                Text("PAUSED")
+                    .font(.caption)
+                    .tracking(3)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 4)
+                    .background(Capsule().fill(Color.yellow.opacity(0.25)))
+                    .foregroundColor(.yellow)
+                    .padding(.top, 8)
+            }
+        }
+    }
+
+    private func percentFTPText(_ value: Double) -> String {
+        let percent = Int((value * 100).rounded())
+        return "\(percent)% FTP"
+    }
+}
+
+/// Per-interval elapsed/remaining timer with interval index.
+private struct IntervalTimerBlock: View {
+    let elapsed: TimeInterval
+    let remaining: TimeInterval
+    let intervalIndex: Int
+    let totalIntervals: Int
+
+    var body: some View {
+        VStack(spacing: 6) {
+            Text("Interval \(min(intervalIndex + 1, totalIntervals)) of \(totalIntervals)")
+                .font(.subheadline)
+                .foregroundColor(.white.opacity(0.7))
+            HStack(spacing: 24) {
+                timeColumn(label: "ELAPSED", value: elapsed)
+                Divider().frame(height: 36).background(Color.white.opacity(0.2))
+                timeColumn(label: "LEFT", value: remaining)
+            }
+        }
+    }
+
+    private func timeColumn(label: String, value: TimeInterval) -> some View {
+        VStack(spacing: 2) {
+            Text(label)
+                .font(.caption2)
+                .tracking(2)
+                .foregroundColor(.white.opacity(0.55))
+            Text(formatTime(value))
+                .font(.system(size: 28, weight: .semibold, design: .rounded))
+                .foregroundColor(.white)
+                .monospacedDigit()
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(label.lowercased()) \(formatTime(value))")
+    }
+}
+
+/// Compact preview of the upcoming interval, or a "last interval" hint.
+private struct NextIntervalPreview: View {
+    let next: Interval?
+    let ftp: Int
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "forward.end.alt.fill")
+                .foregroundColor(.white.opacity(0.7))
+            if let next {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Up next")
+                        .font(.caption)
+                        .foregroundColor(.white.opacity(0.6))
+                    Text(detailLine(for: next))
+                        .font(.subheadline)
+                        .foregroundColor(.white)
+                }
+            } else {
+                Text("Last interval — finish strong")
+                    .font(.subheadline)
+                    .foregroundColor(.white)
+            }
+            Spacer()
+        }
+        .padding(12)
+        .background(RoundedRectangle(cornerRadius: 12).fill(Color.white.opacity(0.08)))
+        .accessibilityElement(children: .combine)
+    }
+
+    private func detailLine(for interval: Interval) -> String {
+        var parts: [String] = ["\(interval.watts) W"]
+        if ftp > 0 {
+            let percent = Int((Double(interval.watts) / Double(ftp) * 100).rounded())
+            parts.append("\(percent)% FTP")
+        }
+        parts.append(formatTime(interval.duration))
+        return parts.joined(separator: " · ")
+    }
+}
+
+/// Overall workout progress with elapsed / remaining readouts.
+private struct OverallProgressBar: View {
+    let progress: Double
+    let overallElapsed: TimeInterval
+    let overallRemaining: TimeInterval
+
+    var body: some View {
+        VStack(spacing: 6) {
+            GeometryReader { geo in
+                ZStack(alignment: .leading) {
+                    Capsule().fill(Color.white.opacity(0.15))
+                    Capsule()
+                        .fill(Color.green)
+                        .frame(width: max(0, min(geo.size.width, geo.size.width * CGFloat(progress))))
+                        .animation(.linear(duration: 0.1), value: progress)
+                }
+            }
+            .frame(height: 8)
+            HStack {
+                Text(formatTime(overallElapsed))
+                Spacer()
+                Text("-\(formatTime(overallRemaining))")
+            }
+            .font(.caption)
+            .monospacedDigit()
+            .foregroundColor(.white.opacity(0.8))
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Overall progress \(Int((progress * 100).rounded())) percent")
+    }
+}
+
+/// Pause/resume + skip + end controls.
+private struct PlayerControlsBar: View {
+    let state: IntervalPlayerState
+    let onPauseResume: () -> Void
+    let onSkip: () -> Void
+    let onEnd: () -> Void
+
+    var body: some View {
+        HStack(spacing: 16) {
+            controlButton(
+                systemName: "stop.fill",
+                label: "End",
+                tint: .red.opacity(0.9),
+                action: onEnd
+            )
+            Spacer()
+            primaryControl
+            Spacer()
+            controlButton(
+                systemName: "forward.fill",
+                label: "Skip",
+                tint: .white.opacity(0.2),
+                action: onSkip,
+                disabled: state == .finished
+            )
+        }
+    }
+
+    private var primaryControl: some View {
+        Button(action: onPauseResume) {
+            Image(systemName: state == .running ? "pause.fill" : "play.fill")
+                .font(.system(size: 32, weight: .bold))
+                .foregroundColor(.black)
+                .frame(width: 84, height: 84)
+                .background(Circle().fill(Color.white))
+        }
+        .disabled(state == .finished || state == .idle)
+        .accessibilityLabel(state == .running ? "Pause" : "Resume")
+    }
+
+    private func controlButton(
+        systemName: String,
+        label: String,
+        tint: Color,
+        action: @escaping () -> Void,
+        disabled: Bool = false
+    ) -> some View {
+        Button(action: action) {
+            VStack(spacing: 4) {
+                Image(systemName: systemName)
+                    .font(.title2)
+                    .foregroundColor(.white)
+                    .frame(width: 56, height: 56)
+                    .background(Circle().fill(tint))
+                Text(label)
+                    .font(.caption)
+                    .foregroundColor(.white.opacity(0.8))
+            }
+        }
+        .disabled(disabled)
+        .opacity(disabled ? 0.4 : 1)
+        .accessibilityLabel(label)
+    }
+}
+
+// MARK: - Helpers
+
+/// Format a `TimeInterval` as `M:SS` (or `H:MM:SS` for hour-plus durations).
+private func formatTime(_ value: TimeInterval) -> String {
+    let total = max(0, Int(value.rounded()))
+    let hours = total / 3600
+    let minutes = (total % 3600) / 60
+    let seconds = total % 60
+    if hours > 0 {
+        return String(format: "%d:%02d:%02d", hours, minutes, seconds)
+    }
+    return String(format: "%d:%02d", minutes, seconds)
+}

--- a/Dropped/Views/WorkoutDetailView.swift
+++ b/Dropped/Views/WorkoutDetailView.swift
@@ -6,6 +6,8 @@ struct WorkoutDetailView: View {
     let workout: Workout
 
     @State private var showingResultEntry = false
+    /// Controls presentation of the full-screen interval player.
+    @State private var isPlayerPresented: Bool = false
 
     var body: some View {
         ScrollView {
@@ -15,6 +17,7 @@ struct WorkoutDetailView: View {
                    let testType = FTPTestType(rawValue: testTypeRaw) {
                     logResultButton(testType: testType)
                 }
+                startWorkoutButton
                 intervalsSection
                 powerProfileSection
             }
@@ -28,6 +31,12 @@ struct WorkoutDetailView: View {
                let testType = FTPTestType(rawValue: testTypeRaw) {
                 FTPTestResultEntryView(testType: testType, sourceWorkout: workout)
             }
+        }
+        .fullScreenCover(isPresented: $isPlayerPresented) {
+            IntervalPlayerView(
+                workout: workout,
+                ftp: UserDataManager.shared.loadUserData().ftp
+            )
         }
     }
 
@@ -45,6 +54,33 @@ struct WorkoutDetailView: View {
             .cornerRadius(12)
         }
         .accessibilityIdentifier("logFTPTestResultButton")
+    }
+
+    /// Primary CTA that launches the guided interval player. Disabled when the
+    /// workout has no intervals to play.
+    private var startWorkoutButton: some View {
+        Button {
+            isPlayerPresented = true
+        } label: {
+            HStack(spacing: 8) {
+                Image(systemName: "play.fill")
+                Text("Start workout")
+                    .fontWeight(.semibold)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 14)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(workout.intervals.isEmpty ? Color.gray.opacity(0.4) : Color.accentColor)
+            )
+            .foregroundColor(.white)
+        }
+        .buttonStyle(.plain)
+        .disabled(workout.intervals.isEmpty)
+        .accessibilityLabel("Start workout")
+        .accessibilityHint(workout.intervals.isEmpty
+            ? "This workout has no intervals to play"
+            : "Begins a guided interval session")
     }
 
     /// List of workout intervals, or an empty state if the workout has none.

--- a/DroppedTests/IntervalPlayerViewModelTests.swift
+++ b/DroppedTests/IntervalPlayerViewModelTests.swift
@@ -1,0 +1,304 @@
+//
+//  IntervalPlayerViewModelTests.swift
+//  DroppedTests
+//
+//  Unit tests for `IntervalPlayerViewModel`. The view model is driven by an
+//  injectable clock and cue handler, so every test below operates on a
+//  deterministic timeline without sleeping.
+//
+
+import XCTest
+@testable import Dropped
+
+@MainActor
+final class IntervalPlayerViewModelTests: XCTestCase {
+
+    // MARK: Test fixtures
+
+    /// A simple three-interval workout used by most tests:
+    ///   • 30s @ 100W
+    ///   • 60s @ 200W
+    ///   • 30s @ 150W  (total 120s)
+    private func makeWorkout() -> Workout {
+        Workout(
+            title: "Test",
+            date: Date(timeIntervalSince1970: 0),
+            summary: "fixture",
+            intervals: [
+                Interval(watts: 100, duration: 30),
+                Interval(watts: 200, duration: 60),
+                Interval(watts: 150, duration: 30)
+            ]
+        )
+    }
+
+    /// A controllable clock plus a recorder for emitted cue intents.
+    private final class Harness {
+        var current: Date = Date(timeIntervalSince1970: 1_000)
+        var cues: [IntervalPlayerCueIntent] = []
+
+        func now() -> Date { current }
+        func record(_ intent: IntervalPlayerCueIntent) { cues.append(intent) }
+        func advance(by seconds: TimeInterval) { current = current.addingTimeInterval(seconds) }
+    }
+
+    private func makePlayer(
+        workout: Workout? = nil,
+        ftp: Int = 250,
+        harness: Harness = Harness()
+    ) -> (IntervalPlayerViewModel, Harness) {
+        let w = workout ?? makeWorkout()
+        let vm = IntervalPlayerViewModel(
+            workout: w,
+            ftp: ftp,
+            now: { harness.now() },
+            cueHandler: { harness.record($0) }
+        )
+        return (vm, harness)
+    }
+
+    // MARK: Lifecycle
+
+    func testStart_setsRunning_andEmitsFirstIntervalStart() {
+        let (vm, h) = makePlayer()
+        vm.start()
+        XCTAssertEqual(vm.state, .running)
+        XCTAssertEqual(vm.currentIndex, 0)
+        XCTAssertEqual(h.cues, [.intervalStarted(index: 0)])
+    }
+
+    func testStart_isNoOp_whenWorkoutHasNoIntervals() {
+        let empty = Workout(title: "Empty", date: Date(), summary: "", intervals: [])
+        let (vm, h) = makePlayer(workout: empty)
+        vm.start()
+        XCTAssertEqual(vm.state, .idle)
+        XCTAssertTrue(h.cues.isEmpty)
+    }
+
+    func testStart_isNoOp_whenAlreadyRunning() {
+        let (vm, h) = makePlayer()
+        vm.start()
+        vm.start()
+        XCTAssertEqual(h.cues, [.intervalStarted(index: 0)])
+    }
+
+    // MARK: Tick advancement
+
+    func testTick_advancesElapsed_andDecrementsRemaining() {
+        let (vm, h) = makePlayer()
+        vm.start()
+        h.advance(by: 10)
+        vm.tick()
+        XCTAssertEqual(vm.elapsedInInterval, 10, accuracy: 0.001)
+        XCTAssertEqual(vm.remainingInInterval, 20, accuracy: 0.001)
+        XCTAssertEqual(vm.overallElapsed, 10, accuracy: 0.001)
+        XCTAssertEqual(vm.overallRemaining, 110, accuracy: 0.001)
+    }
+
+    func testTick_crossesIntervalBoundary_advancesIndex_andEmitsEndAndStartCues() {
+        let (vm, h) = makePlayer()
+        vm.start()
+        h.advance(by: 31) // 1s into interval 1
+        vm.tick()
+        XCTAssertEqual(vm.currentIndex, 1)
+        XCTAssertEqual(vm.elapsedInInterval, 1, accuracy: 0.01)
+        XCTAssertEqual(h.cues, [
+            .intervalStarted(index: 0),
+            .intervalEnded(index: 0),
+            .intervalStarted(index: 1)
+        ])
+    }
+
+    func testTick_crossesMultipleIntervals_inSingleStep() {
+        // Simulate a long background gap that spans the entire second interval.
+        let (vm, h) = makePlayer()
+        vm.start()
+        h.advance(by: 95) // past intervals 0 and 1, 5s into interval 2
+        vm.tick()
+        XCTAssertEqual(vm.currentIndex, 2)
+        XCTAssertEqual(vm.elapsedInInterval, 5, accuracy: 0.01)
+        // Boundaries should still emit end+start in order.
+        XCTAssertEqual(h.cues, [
+            .intervalStarted(index: 0),
+            .intervalEnded(index: 0),
+            .intervalStarted(index: 1),
+            .intervalEnded(index: 1),
+            .intervalStarted(index: 2)
+        ])
+    }
+
+    // MARK: Countdown
+
+    func testCountdown_emits3_2_1_exactlyOnce_perInterval() {
+        let (vm, h) = makePlayer()
+        vm.start()
+        // Walk forward in 0.25s steps through the last 4 seconds of interval 0
+        // (i.e. from t=26.0 to t=30.0). Many ticks land in the same second; we
+        // expect exactly one cue per integer second.
+        var t: TimeInterval = 0
+        h.advance(by: 26)
+        vm.tick()
+        for _ in 0..<16 {
+            h.advance(by: 0.25)
+            t += 0.25
+            vm.tick()
+        }
+        let countdownCues = h.cues.filter {
+            if case .countdownTick = $0 { return true } else { return false }
+        }
+        XCTAssertEqual(countdownCues, [
+            .countdownTick(secondsRemaining: 3),
+            .countdownTick(secondsRemaining: 2),
+            .countdownTick(secondsRemaining: 1)
+        ])
+    }
+
+    func testCountdown_resetsBetweenIntervals() {
+        let (vm, h) = makePlayer()
+        vm.start()
+        h.advance(by: 30) // exactly to boundary -> advance to interval 1
+        vm.tick()
+        // Now sweep through the end of interval 1 (60s long, so countdown
+        // happens at remaining=3,2,1 -> elapsedInInterval ~ 57,58,59).
+        h.advance(by: 57)
+        vm.tick()
+        h.advance(by: 1)
+        vm.tick()
+        h.advance(by: 1)
+        vm.tick()
+        let countdownCues = h.cues.filter {
+            if case .countdownTick = $0 { return true } else { return false }
+        }
+        XCTAssertEqual(countdownCues, [
+            .countdownTick(secondsRemaining: 3),
+            .countdownTick(secondsRemaining: 2),
+            .countdownTick(secondsRemaining: 1)
+        ])
+    }
+
+    // MARK: Pause / resume
+
+    func testPause_thenResume_doesNotLoseElapsed_acrossWallClockGap() {
+        let (vm, h) = makePlayer()
+        vm.start()
+        h.advance(by: 10)
+        vm.tick()
+        vm.pause()
+        XCTAssertEqual(vm.state, .paused)
+        XCTAssertEqual(vm.elapsedInInterval, 10, accuracy: 0.001)
+
+        // Simulate the user pausing for 5 minutes (e.g. app backgrounded).
+        h.advance(by: 300)
+        vm.resume()
+        XCTAssertEqual(vm.state, .running)
+        // No additional in-interval time should have accrued.
+        XCTAssertEqual(vm.elapsedInInterval, 10, accuracy: 0.05)
+
+        // Now real workout time advances normally.
+        h.advance(by: 5)
+        vm.tick()
+        XCTAssertEqual(vm.elapsedInInterval, 15, accuracy: 0.05)
+    }
+
+    func testPause_isNoOp_whenNotRunning() {
+        let (vm, _) = makePlayer()
+        vm.pause()
+        XCTAssertEqual(vm.state, .idle)
+    }
+
+    // MARK: Skip
+
+    func testSkip_movesToNextInterval_andEmitsCues() {
+        let (vm, h) = makePlayer()
+        vm.start()
+        h.advance(by: 5)
+        vm.tick()
+        h.cues.removeAll()
+        vm.skip()
+        XCTAssertEqual(vm.currentIndex, 1)
+        XCTAssertEqual(vm.elapsedInInterval, 0, accuracy: 0.001)
+        XCTAssertEqual(h.cues, [
+            .intervalEnded(index: 0),
+            .intervalStarted(index: 1)
+        ])
+    }
+
+    func testSkip_onLastInterval_finishesWorkout_withoutNaturalCompletionCue() {
+        let (vm, h) = makePlayer()
+        vm.start()
+        // Jump straight to the last interval.
+        h.advance(by: 90)
+        vm.tick()
+        XCTAssertEqual(vm.currentIndex, 2)
+        h.cues.removeAll()
+        vm.skip()
+        XCTAssertEqual(vm.state, .finished)
+        XCTAssertEqual(h.cues, [.intervalEnded(index: 2)])
+        XCTAssertFalse(h.cues.contains(.workoutCompleted))
+    }
+
+    // MARK: End early
+
+    func testEndEarly_setsFinished_andStopsFurtherCues() {
+        let (vm, h) = makePlayer()
+        vm.start()
+        h.advance(by: 5)
+        vm.tick()
+        h.cues.removeAll()
+        vm.endEarly()
+        XCTAssertEqual(vm.state, .finished)
+        XCTAssertTrue(h.cues.isEmpty, "endEarly should not emit a completion cue")
+
+        // Subsequent ticks are no-ops.
+        h.advance(by: 60)
+        vm.tick()
+        XCTAssertTrue(h.cues.isEmpty)
+    }
+
+    // MARK: Natural completion
+
+    func testNaturalCompletion_emitsWorkoutCompleted_exactlyOnce() {
+        let (vm, h) = makePlayer()
+        vm.start()
+        h.advance(by: 200) // well past the 120s total
+        vm.tick()
+        XCTAssertEqual(vm.state, .finished)
+        let completionCount = h.cues.filter { $0 == .workoutCompleted }.count
+        XCTAssertEqual(completionCount, 1)
+
+        // Extra ticks do not re-fire.
+        vm.tick()
+        let completionCount2 = h.cues.filter { $0 == .workoutCompleted }.count
+        XCTAssertEqual(completionCount2, 1)
+    }
+
+    // MARK: Progress + targets
+
+    func testProgressFraction_isMonotonic_andClampedTo0_1() {
+        let (vm, h) = makePlayer()
+        vm.start()
+        var last: Double = -1
+        for step in stride(from: 0, through: 200, by: 5) {
+            h.current = Date(timeIntervalSince1970: 1_000 + Double(step))
+            vm.tick()
+            XCTAssertGreaterThanOrEqual(vm.progressFraction, last)
+            XCTAssertGreaterThanOrEqual(vm.progressFraction, 0)
+            XCTAssertLessThanOrEqual(vm.progressFraction, 1)
+            last = vm.progressFraction
+        }
+        XCTAssertEqual(vm.progressFraction, 1, accuracy: 0.0001)
+    }
+
+    func testCurrentTargetWatts_andPercentFTP() {
+        let (vm, _) = makePlayer(ftp: 200)
+        vm.start()
+        XCTAssertEqual(vm.currentTargetWatts, 100)
+        XCTAssertEqual(vm.currentPercentFTP ?? 0, 0.5, accuracy: 0.0001)
+    }
+
+    func testPercentFTP_isNil_whenFTPIsZero() {
+        let (vm, _) = makePlayer(ftp: 0)
+        vm.start()
+        XCTAssertNil(vm.currentPercentFTP)
+    }
+}

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -35,6 +35,11 @@ This project is a SwiftUI-based iOS cycling training application.
 - **OnboardingViewModel.swift**: Onboarding validation, unit conversion, and profile-save logic.
 - **WorkoutGeneratorViewModel.swift**: AI workout generator state, loading/error handling, and generated-workout acceptance into persisted workout storage.
 - **FTPTestResultViewModel.swift**: Validates a rider's FTP-test result entry, computes the new FTP, and persists it via injected `UserDataManager`/`WorkoutManager` (also marks the source test workout completed).
+- **IntervalPlayerViewModel.swift**: Pure, testable state machine for the in-app interval player. Drives interval progression via an injectable wall-clock and emits `IntervalPlayerCueIntent` values for audio/haptic side effects.
+
+#### Dropped/Services/
+
+- **IntervalCueService.swift**: Translates `IntervalPlayerCueIntent` values into AVFoundation system sounds, `UIImpactFeedbackGenerator` haptics, and `AVSpeechSynthesizer` spoken cues. Configures the shared `AVAudioSession` for playback during a session.
 
 #### Dropped/Views/
 
@@ -42,7 +47,8 @@ This project is a SwiftUI-based iOS cycling training application.
 - **OnboardingView.swift**: Rider profile setup screen.
 - **PlanSummaryView.swift**: Training plan summary, generated workout cards, settings entry point, and onboarding reset.
 - **SettingsView.swift**: Settings screen for preferred weight units and app information.
-- **WorkoutDetailView.swift**: Detailed workout screen with overview, interval list, and inline power/time graph.
+- **WorkoutDetailView.swift**: Detailed workout screen with overview, interval list, inline power/time graph, and a "Start workout" CTA that presents the full-screen interval player.
+- **IntervalPlayerView.swift**: Full-screen guided interval player. Hosts `IntervalPlayerViewModel`, drives a 10 Hz timer, plays cues via `IntervalCueService`, keeps the screen awake (`isIdleTimerDisabled`), and exposes pause/resume/skip/end-early controls.
 - **WorkoutGeneratorView.swift**: AI workout type selection and generation screen.
 - **WorkoutGeneratorReviewView.swift**: Review surface for accepting or regenerating an AI-generated workout.
 - **PowerZonesView.swift**: Lists Coggan zones Z1–Z7 with %FTP ranges and target wattages computed from the rider's current FTP. Includes a link to the FTP tests screen.
@@ -61,6 +67,7 @@ This project is a SwiftUI-based iOS cycling training application.
 - **PowerZonesTests.swift**: Unit tests for Coggan zone boundary classification, watt-range computation across FTPs (including FTP=0), and `UserData.powerZones`.
 - **FTPTestWorkoutsTests.swift**: Unit tests for the structure of built-in FTP test workouts and `Workout` codable backward compatibility for the new `testKind` field.
 - **FTPTestResultViewModelTests.swift**: Unit tests for the result-entry view model using isolated `UserDefaults`, covering profile updates, validation, and the source-workout completion side effect.
+- **IntervalPlayerViewModelTests.swift**: Unit tests for the interval player state machine: lifecycle, tick advancement across boundaries (including multi-interval jumps), countdown cue de-duplication, pause/resume across simulated background gaps, skip, end-early, natural completion, progress monotonicity, and watts/%FTP calculations.
 
 ### DroppedUITests/
 


### PR DESCRIPTION
## Why

Riders could plan workouts but had no way to actually *do* one inside the app. This adds a guided, full-screen interval player so a planned workout can be executed in real time with audio + haptic cues, just like a coach calling out the next effort.

## What

- **`IntervalPlayerViewModel`** — a pure, `@MainActor` state machine (`idle / running / paused / finished`) that drives interval progression. Time is read through an injectable `now()` closure and side effects are emitted as `IntervalPlayerCueIntent` values, so the engine has zero AVFoundation/UIKit dependencies and is fully unit-testable.
- **`IntervalCueService`** — translates cue intents into `AVAudioSession`-configured system tones, `UIImpactFeedbackGenerator` haptics (light for countdown, medium for end, heavy for start, success notification for completion), and `AVSpeechSynthesizer` spoken cues ("Next: 250 watts for 2 minutes"). Mixes with other audio and ducks rather than killing the rider's music.
- **`IntervalPlayerView`** — full-screen player presented via `.fullScreenCover` from a new "Start workout" CTA on `WorkoutDetailView`. Shows the big target watts + % FTP, per-interval elapsed/left, an overall progress bar, an "Up next" preview, and pause / resume / skip / end-with-confirm controls. Holds `isIdleTimerDisabled = true` for its lifetime.
- **17 unit tests** in `IntervalPlayerViewModelTests` covering the timeline behavior.

## Notable design choices

- **Wall-clock anchored timing.** Instead of trusting a `Timer` to keep firing while backgrounded, the view model stores the `Date` when the current interval started and recomputes elapsed time from `now()` on every tick *and* on `scenePhase == .active`. The included `pause / resume across a 5-minute simulated wall-clock gap` test pins this behavior.
- **Carry-over on boundary crossings.** If a single tick spans multiple intervals (e.g. after returning from background), the view model walks forward through each, emits ordered `intervalEnded` / `intervalStarted` cues, and carries leftover seconds into the new interval so the session never drifts.
- **Countdown de-duplication.** A `lastEmittedCountdownSecond` guard ensures the 3-2-1 cue fires exactly once per second per interval, even when the UI ticks at 10 Hz.
- **Skip vs. natural completion.** Skipping past the last interval finishes the workout but does *not* emit `workoutCompleted`; that intent is reserved for natural completion so the celebratory chime only plays when the rider actually finished the work.

## Out of scope

Live Activities / Dynamic Island, persisting partial progress across app launches, BLE power meter integration, and long-suspend background audio. These are good follow-ups but intentionally not in this change.

## Verification

- Builds clean against iPhone 17 simulator.
- All 17 new unit tests pass; existing tests untouched.