### PR TITLE
Add HealthKit integration: read rider metrics, write completed cycling workouts

### DIFF
--- a/Dropped.xcodeproj/project.pbxproj
+++ b/Dropped.xcodeproj/project.pbxproj
@@ -393,6 +393,8 @@
 				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHealthShareUsageDescription = "Dropped reads your weight, resting heart rate, VO2 max, and cycling FTP from Health to keep your rider profile accurate.";
+				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "Dropped saves your completed cycling workouts to Health so they're part of your activity history.";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
@@ -430,6 +432,8 @@
 				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSHealthShareUsageDescription = "Dropped reads your weight, resting heart rate, VO2 max, and cycling FTP from Health to keep your rider profile accurate.";
+				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "Dropped saves your completed cycling workouts to Health so they're part of your activity history.";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;

--- a/Dropped/Dropped.entitlements
+++ b/Dropped/Dropped.entitlements
@@ -6,5 +6,9 @@
     <true/>
     <key>com.apple.security.files.user-selected.read-only</key>
     <true/>
+    <key>com.apple.developer.healthkit</key>
+    <true/>
+    <key>com.apple.developer.healthkit.access</key>
+    <array/>
 </dict>
 </plist>

--- a/Dropped/Models/HealthKitService.swift
+++ b/Dropped/Models/HealthKitService.swift
@@ -1,0 +1,276 @@
+//
+//  HealthKitService.swift
+//  Dropped
+//
+//  Wraps HealthKit for reading rider metrics and writing completed cycling workouts.
+//  Protocol-based so tests can stub the integration without touching HKHealthStore.
+//
+
+import Foundation
+#if canImport(HealthKit) && !os(macOS)
+import HealthKit
+#endif
+
+// MARK: - Value types
+
+/// Snapshot of a completed cycling workout for persistence to HealthKit.
+struct CompletedWorkoutSummary: Equatable {
+    let start: Date
+    let end: Date
+    /// Optional override for kcal burned. When nil, the service estimates from `averagePowerWatts`
+    /// using a typical cycling gross efficiency.
+    let totalEnergyKilocalories: Double?
+    let averageHeartRate: Double?
+    let averagePowerWatts: Int?
+    let distanceMeters: Double?
+    let isIndoor: Bool
+
+    init(start: Date,
+         end: Date,
+         totalEnergyKilocalories: Double? = nil,
+         averageHeartRate: Double? = nil,
+         averagePowerWatts: Int? = nil,
+         distanceMeters: Double? = nil,
+         isIndoor: Bool = true) {
+        self.start = start
+        self.end = end
+        self.totalEnergyKilocalories = totalEnergyKilocalories
+        self.averageHeartRate = averageHeartRate
+        self.averagePowerWatts = averagePowerWatts
+        self.distanceMeters = distanceMeters
+        self.isIndoor = isIndoor
+    }
+
+    var duration: TimeInterval { end.timeIntervalSince(start) }
+
+    /// Estimate metabolic active kcal from average mechanical power.
+    /// Uses gross cycling efficiency of ~23% (typical range 20–25%):
+    ///   metabolicJoules = (watts × seconds) / 0.23
+    ///   kcal = metabolicJoules / 4184
+    /// HealthKit's `activeEnergyBurned` expects metabolic kcal, not mechanical work.
+    static func estimateKilocalories(averagePowerWatts: Int, duration: TimeInterval) -> Double {
+        guard averagePowerWatts > 0, duration > 0 else { return 0 }
+        let mechanicalJoules = Double(averagePowerWatts) * duration
+        let metabolicJoules = mechanicalJoules / 0.23
+        return metabolicJoules / 4184.0
+    }
+}
+
+enum HealthKitServiceError: Error, Equatable {
+    case unavailable
+    case notAuthorized
+    case underlying(String)
+}
+
+// MARK: - Protocol
+
+protocol HealthKitServicing {
+    var isAvailable: Bool { get }
+    func requestAuthorization() async throws
+    func latestBodyMassKg() async throws -> (mass: Double, date: Date)?
+    func latestRestingHeartRate() async throws -> Double?
+    func latestVO2Max() async throws -> Double?
+    func latestCyclingFTP() async throws -> Int?
+    func saveCyclingWorkout(_ summary: CompletedWorkoutSummary) async throws
+}
+
+// MARK: - Default implementation
+
+final class HealthKitService: HealthKitServicing {
+    static let shared = HealthKitService()
+
+    #if canImport(HealthKit) && !os(macOS)
+    private let store = HKHealthStore()
+    #endif
+
+    init() {}
+
+    var isAvailable: Bool {
+        #if canImport(HealthKit) && !os(macOS)
+        return HKHealthStore.isHealthDataAvailable()
+        #else
+        return false
+        #endif
+    }
+
+    func requestAuthorization() async throws {
+        #if canImport(HealthKit) && !os(macOS)
+        guard isAvailable else { throw HealthKitServiceError.unavailable }
+        var read: Set<HKObjectType> = []
+        if let bodyMass = HKObjectType.quantityType(forIdentifier: .bodyMass) {
+            read.insert(bodyMass)
+        }
+        if let restingHR = HKObjectType.quantityType(forIdentifier: .restingHeartRate) {
+            read.insert(restingHR)
+        }
+        if let vo2 = HKObjectType.quantityType(forIdentifier: .vo2Max) {
+            read.insert(vo2)
+        }
+        if let hr = HKObjectType.quantityType(forIdentifier: .heartRate) {
+            read.insert(hr)
+        }
+        if #available(iOS 17.0, watchOS 10.0, macOS 14.0, visionOS 1.0, *) {
+            if let ftp = HKObjectType.quantityType(forIdentifier: .cyclingFunctionalThresholdPower) {
+                read.insert(ftp)
+            }
+        }
+        var write: Set<HKSampleType> = [HKObjectType.workoutType()]
+        if let energy = HKObjectType.quantityType(forIdentifier: .activeEnergyBurned) {
+            write.insert(energy)
+        }
+        if let hr = HKObjectType.quantityType(forIdentifier: .heartRate) {
+            write.insert(hr)
+        }
+        if let distance = HKObjectType.quantityType(forIdentifier: .distanceCycling) {
+            write.insert(distance)
+        }
+        try await store.requestAuthorization(toShare: write, read: read)
+        #else
+        throw HealthKitServiceError.unavailable
+        #endif
+    }
+
+    func latestBodyMassKg() async throws -> (mass: Double, date: Date)? {
+        #if canImport(HealthKit) && !os(macOS)
+        guard isAvailable,
+              let type = HKQuantityType.quantityType(forIdentifier: .bodyMass) else { return nil }
+        guard let sample = try await latestSample(of: type) else { return nil }
+        let kg = sample.quantity.doubleValue(for: .gramUnit(with: .kilo))
+        return (kg, sample.endDate)
+        #else
+        return nil
+        #endif
+    }
+
+    func latestRestingHeartRate() async throws -> Double? {
+        #if canImport(HealthKit) && !os(macOS)
+        guard isAvailable,
+              let type = HKQuantityType.quantityType(forIdentifier: .restingHeartRate) else { return nil }
+        guard let sample = try await latestSample(of: type) else { return nil }
+        let bpm = HKUnit.count().unitDivided(by: .minute())
+        return sample.quantity.doubleValue(for: bpm)
+        #else
+        return nil
+        #endif
+    }
+
+    func latestVO2Max() async throws -> Double? {
+        #if canImport(HealthKit) && !os(macOS)
+        guard isAvailable,
+              let type = HKQuantityType.quantityType(forIdentifier: .vo2Max) else { return nil }
+        guard let sample = try await latestSample(of: type) else { return nil }
+        // mL/(kg·min)
+        let unit = HKUnit.literUnit(with: .milli)
+            .unitDivided(by: HKUnit.gramUnit(with: .kilo).unitMultiplied(by: .minute()))
+        return sample.quantity.doubleValue(for: unit)
+        #else
+        return nil
+        #endif
+    }
+
+    func latestCyclingFTP() async throws -> Int? {
+        #if canImport(HealthKit) && !os(macOS)
+        guard isAvailable else { return nil }
+        if #available(iOS 17.0, watchOS 10.0, macOS 14.0, visionOS 1.0, *) {
+            guard let type = HKQuantityType.quantityType(forIdentifier: .cyclingFunctionalThresholdPower) else {
+                return nil
+            }
+            guard let sample = try await latestSample(of: type) else { return nil }
+            return Int(sample.quantity.doubleValue(for: .watt()).rounded())
+        }
+        return nil
+        #else
+        return nil
+        #endif
+    }
+
+    func saveCyclingWorkout(_ summary: CompletedWorkoutSummary) async throws {
+        #if canImport(HealthKit) && !os(macOS)
+        guard isAvailable else { throw HealthKitServiceError.unavailable }
+
+        let configuration = HKWorkoutConfiguration()
+        configuration.activityType = .cycling
+        configuration.locationType = summary.isIndoor ? .indoor : .outdoor
+
+        let builder = HKWorkoutBuilder(healthStore: store,
+                                       configuration: configuration,
+                                       device: .local())
+        try await builder.beginCollection(at: summary.start)
+
+        let kcal = summary.totalEnergyKilocalories
+            ?? CompletedWorkoutSummary.estimateKilocalories(
+                averagePowerWatts: summary.averagePowerWatts ?? 0,
+                duration: summary.duration
+            )
+
+        var samples: [HKSample] = []
+        if kcal > 0,
+           let energyType = HKQuantityType.quantityType(forIdentifier: .activeEnergyBurned) {
+            let quantity = HKQuantity(unit: .kilocalorie(), doubleValue: kcal)
+            samples.append(HKQuantitySample(type: energyType,
+                                            quantity: quantity,
+                                            start: summary.start,
+                                            end: summary.end))
+        }
+        if let hr = summary.averageHeartRate, hr > 0,
+           let hrType = HKQuantityType.quantityType(forIdentifier: .heartRate) {
+            let bpm = HKUnit.count().unitDivided(by: .minute())
+            let quantity = HKQuantity(unit: bpm, doubleValue: hr)
+            samples.append(HKQuantitySample(type: hrType,
+                                            quantity: quantity,
+                                            start: summary.start,
+                                            end: summary.end))
+        }
+        if let meters = summary.distanceMeters, meters > 0,
+           let distanceType = HKQuantityType.quantityType(forIdentifier: .distanceCycling) {
+            let quantity = HKQuantity(unit: .meter(), doubleValue: meters)
+            samples.append(HKQuantitySample(type: distanceType,
+                                            quantity: quantity,
+                                            start: summary.start,
+                                            end: summary.end))
+        }
+        if !samples.isEmpty {
+            try await builder.addSamples(samples)
+        }
+
+        try await builder.endCollection(at: summary.end)
+        _ = try await builder.finishWorkout()
+        #else
+        throw HealthKitServiceError.unavailable
+        #endif
+    }
+
+    // MARK: - Helpers
+
+    #if canImport(HealthKit) && !os(macOS)
+    private func latestSample(of type: HKQuantityType) async throws -> HKQuantitySample? {
+        try await withCheckedThrowingContinuation { continuation in
+            let sort = NSSortDescriptor(key: HKSampleSortIdentifierEndDate, ascending: false)
+            let query = HKSampleQuery(sampleType: type,
+                                      predicate: nil,
+                                      limit: 1,
+                                      sortDescriptors: [sort]) { _, samples, error in
+                if let error {
+                    continuation.resume(throwing: HealthKitServiceError.underlying(error.localizedDescription))
+                    return
+                }
+                continuation.resume(returning: samples?.first as? HKQuantitySample)
+            }
+            store.execute(query)
+        }
+    }
+    #endif
+}
+
+// MARK: - Profile sync helper
+
+extension HealthKitServicing {
+    /// Pull the latest body mass from HealthKit and apply to the user profile if newer.
+    /// Returns true when a profile update occurred.
+    @discardableResult
+    func syncBodyMassToProfile(using manager: UserDataManager = .shared) async -> Bool {
+        guard isAvailable else { return false }
+        guard let latest = try? await latestBodyMassKg() else { return false }
+        return manager.updateWeightFromHealth(kg: latest.mass, sampleDate: latest.date)
+    }
+}

--- a/Dropped/Models/UserData.swift
+++ b/Dropped/Models/UserData.swift
@@ -135,13 +135,29 @@ struct UserData: Codable, Equatable {
     var ftp: Int
     var trainingHoursPerWeek: Int
     var trainingGoal: String
+    var weightUpdatedAt: Date?
+
+    init(weight: Double,
+         weightUnit: String,
+         ftp: Int,
+         trainingHoursPerWeek: Int,
+         trainingGoal: String,
+         weightUpdatedAt: Date? = nil) {
+        self.weight = weight
+        self.weightUnit = weightUnit
+        self.ftp = ftp
+        self.trainingHoursPerWeek = trainingHoursPerWeek
+        self.trainingGoal = trainingGoal
+        self.weightUpdatedAt = weightUpdatedAt
+    }
     
     static let defaultData = UserData(
         weight: 70.0, 
         weightUnit: WeightUnit.pounds.rawValue,
         ftp: 200, 
         trainingHoursPerWeek: 5, 
-        trainingGoal: TrainingGoal.haveFun.rawValue
+        trainingGoal: TrainingGoal.haveFun.rawValue,
+        weightUpdatedAt: nil
     )
     
     /// Helper function to get weight in the user's preferred unit
@@ -221,17 +237,43 @@ class UserDataManager {
         defaults.removeObject(forKey: userDataKey)
         defaults.removeObject(forKey: onboardingCompletedKey)
     }
+
+    /// Update the stored user weight from a HealthKit reading.
+    /// We only overwrite when:
+    ///   - the profile already has a `weightUpdatedAt` and the HK sample is newer, OR
+    ///   - the profile has no `weightUpdatedAt` (never sourced from Health) AND the HK sample is recent
+    ///     (within the last 30 days), so we don't clobber a fresh manual entry with stale Health data.
+    /// Returns true if an update was applied.
+    @discardableResult
+    func updateWeightFromHealth(kg: Double, sampleDate: Date, now: Date = Date()) -> Bool {
+        var current = loadUserData()
+        if let existing = current.weightUpdatedAt {
+            guard sampleDate > existing else { return false }
+        } else {
+            // No prior Health-sourced weight. Be conservative: only accept recent samples.
+            let thirtyDays: TimeInterval = 30 * 24 * 60 * 60
+            guard now.timeIntervalSince(sampleDate) <= thirtyDays else { return false }
+        }
+        current.weight = kg
+        current.weightUpdatedAt = sampleDate
+        saveUserData(current)
+        return true
+    }
 }
 
 /// Manager class for persisted workout data storage and retrieval.
 class WorkoutManager {
     static let shared = WorkoutManager()
+    static let healthSyncEnabledKey = "com.dropped.healthSyncEnabled"
     private let workoutsKey = "com.dropped.workouts"
     private let workoutDaysKey = "com.dropped.workoutDays"
     private let defaults: UserDefaults
-    
-    private init(defaults: UserDefaults = .standard) {
+    private let healthKitService: HealthKitServicing
+
+    init(defaults: UserDefaults = .standard,
+         healthKitService: HealthKitServicing = HealthKitService.shared) {
         self.defaults = defaults
+        self.healthKitService = healthKitService
     }
     
     // MARK: - Workout Management
@@ -323,6 +365,28 @@ class WorkoutManager {
     func createWorkoutDay(for workout: Workout, notes: String? = nil) -> WorkoutDay {
         let userData = UserDataManager.shared.loadUserData()
         return WorkoutDay(userData: userData, workout: workout, notes: notes)
+    }
+
+    /// Mark a workout completed and, if Health sync is enabled, write it to HealthKit.
+    /// Persisted status is updated regardless of HealthKit success/failure.
+    /// Returns the resulting completed workout for callers that need it.
+    @discardableResult
+    func markWorkoutCompleted(_ workout: Workout,
+                              summary: CompletedWorkoutSummary) async -> Workout {
+        let completed = Workout(
+            id: workout.id,
+            title: workout.title,
+            date: workout.date,
+            summary: workout.summary,
+            intervals: workout.intervals,
+            status: .completed
+        )
+        saveWorkout(completed)
+
+        if defaults.bool(forKey: WorkoutManager.healthSyncEnabledKey) {
+            try? await healthKitService.saveCyclingWorkout(summary)
+        }
+        return completed
     }
 
     func resetWorkouts() {

--- a/Dropped/Views/SettingsView.swift
+++ b/Dropped/Views/SettingsView.swift
@@ -11,11 +11,19 @@ class SettingsViewModel: ObservableObject {
     @Published var userData: UserData
     @Published var selectedWeightUnit: WeightUnit
     @Published var isMetric: Bool
-    
-    init() {
-        let loadedData = UserDataManager.shared.loadUserData()
+    @Published var healthSyncStatus: String?
+    @Published var isRequestingHealthAuth: Bool = false
+
+    private let healthKitService: HealthKitServicing
+    private let userDataManager: UserDataManager
+
+    init(healthKitService: HealthKitServicing = HealthKitService.shared,
+         userDataManager: UserDataManager = .shared) {
+        self.healthKitService = healthKitService
+        self.userDataManager = userDataManager
+        let loadedData = userDataManager.loadUserData()
         self.userData = loadedData
-        
+
         if let storedUnit = WeightUnit(rawValue: loadedData.weightUnit) {
             self.selectedWeightUnit = storedUnit
             self.isMetric = (storedUnit == .kilograms)
@@ -24,6 +32,8 @@ class SettingsViewModel: ObservableObject {
             self.isMetric = false
         }
     }
+
+    var isHealthAvailable: Bool { healthKitService.isAvailable }
     
     func toggleUnitSystem() {
         isMetric.toggle()
@@ -55,12 +65,36 @@ class SettingsViewModel: ObservableObject {
     private func updatePreferredUnit() {
         // Keep the weight value in kg, just update the display unit
         userData.weightUnit = selectedWeightUnit.rawValue
-        UserDataManager.shared.saveUserData(userData)
+        userDataManager.saveUserData(userData)
+    }
+
+    @MainActor
+    func requestHealthAuthorization() async {
+        guard healthKitService.isAvailable else {
+            healthSyncStatus = "Apple Health is not available on this device."
+            UserDefaults.standard.set(false, forKey: WorkoutManager.healthSyncEnabledKey)
+            return
+        }
+        isRequestingHealthAuth = true
+        defer { isRequestingHealthAuth = false }
+        do {
+            try await healthKitService.requestAuthorization()
+            let updated = await healthKitService.syncBodyMassToProfile(using: userDataManager)
+            userData = userDataManager.loadUserData()
+            healthSyncStatus = updated
+                ? "Permissions granted. Profile weight updated from Health."
+                : "Permissions granted."
+        } catch {
+            // Roll back the toggle so the app doesn't think sync is on after a denial/failure.
+            UserDefaults.standard.set(false, forKey: WorkoutManager.healthSyncEnabledKey)
+            healthSyncStatus = "Couldn't authorize Apple Health: \(error.localizedDescription)"
+        }
     }
 }
 
 struct SettingsView: View {
     @StateObject private var viewModel = SettingsViewModel()
+    @AppStorage(WorkoutManager.healthSyncEnabledKey) private var healthSyncEnabled: Bool = false
     @Environment(\.dismiss) private var dismiss
     
     var body: some View {
@@ -121,6 +155,40 @@ struct SettingsView: View {
                     .padding(.vertical, 8)
                 }
                 
+                // Apple Health Section
+                Section(header: Text("Apple Health"),
+                        footer: Text(viewModel.isHealthAvailable
+                                     ? "When enabled, completed cycling workouts are written to Health and your weight stays in sync."
+                                     : "Apple Health isn't available on this device.")) {
+                    Toggle("Sync with Apple Health", isOn: $healthSyncEnabled)
+                        .disabled(!viewModel.isHealthAvailable)
+                        .onChange(of: healthSyncEnabled) { _, isOn in
+                            guard isOn else { return }
+                            Task { await viewModel.requestHealthAuthorization() }
+                        }
+
+                    Button {
+                        Task { await viewModel.requestHealthAuthorization() }
+                    } label: {
+                        HStack {
+                            Text("Re-request Permissions")
+                            Spacer()
+                            if viewModel.isRequestingHealthAuth {
+                                ProgressView()
+                            } else {
+                                Image(systemName: "arrow.triangle.2.circlepath")
+                            }
+                        }
+                    }
+                    .disabled(!viewModel.isHealthAvailable || viewModel.isRequestingHealthAuth)
+
+                    if let status = viewModel.healthSyncStatus {
+                        Text(status)
+                            .font(.footnote)
+                            .foregroundColor(.secondary)
+                    }
+                }
+
                 // About Section
                 Section(header: Text("About")) {
                     HStack {

--- a/DroppedTests/HealthKitServiceTests.swift
+++ b/DroppedTests/HealthKitServiceTests.swift
@@ -1,0 +1,218 @@
+//
+//  HealthKitServiceTests.swift
+//  DroppedTests
+//
+//  Tests for HealthKit integration plumbing using a stub service.
+//
+
+import XCTest
+@testable import Dropped
+
+final class MockHealthKitService: HealthKitServicing {
+    var isAvailable: Bool = true
+    var authorizationCalls: Int = 0
+    var authorizationError: Error?
+    var bodyMass: (mass: Double, date: Date)?
+    var restingHR: Double?
+    var vo2: Double?
+    var ftp: Int?
+    var savedSummaries: [CompletedWorkoutSummary] = []
+    var saveError: Error?
+
+    func requestAuthorization() async throws {
+        authorizationCalls += 1
+        if let authorizationError { throw authorizationError }
+    }
+    func latestBodyMassKg() async throws -> (mass: Double, date: Date)? { bodyMass }
+    func latestRestingHeartRate() async throws -> Double? { restingHR }
+    func latestVO2Max() async throws -> Double? { vo2 }
+    func latestCyclingFTP() async throws -> Int? { ftp }
+    func saveCyclingWorkout(_ summary: CompletedWorkoutSummary) async throws {
+        if let saveError { throw saveError }
+        savedSummaries.append(summary)
+    }
+}
+
+final class HealthKitServiceTests: XCTestCase {
+
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+
+    override func setUpWithError() throws {
+        suiteName = "HealthKitServiceTests-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+        UserDataManager.shared.resetUserData()
+        WorkoutManager.shared.resetWorkouts()
+        defaults.removeObject(forKey: WorkoutManager.healthSyncEnabledKey)
+    }
+
+    override func tearDownWithError() throws {
+        UserDataManager.shared.resetUserData()
+        WorkoutManager.shared.resetWorkouts()
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+    }
+
+    // MARK: - Energy estimation
+
+    func test_estimateKilocalories_convertsPowerAndDuration() {
+        // 200 W mechanical for 3600 s, at ~23% efficiency:
+        //   metabolicJ = 200*3600 / 0.23 ≈ 3,130,434
+        //   kcal       = / 4184           ≈ 748.2
+        let kcal = CompletedWorkoutSummary.estimateKilocalories(
+            averagePowerWatts: 200, duration: 3600
+        )
+        XCTAssertEqual(kcal, 748.2, accuracy: 1.0)
+    }
+
+    func test_estimateKilocalories_zeroForBadInputs() {
+        XCTAssertEqual(CompletedWorkoutSummary.estimateKilocalories(averagePowerWatts: 0, duration: 3600), 0)
+        XCTAssertEqual(CompletedWorkoutSummary.estimateKilocalories(averagePowerWatts: 200, duration: 0), 0)
+    }
+
+    // MARK: - Body mass sync
+
+    func test_syncBodyMass_updatesProfile_whenSampleNewer() async {
+        let service = MockHealthKitService()
+        service.bodyMass = (mass: 72.5, date: Date())
+        UserDataManager.shared.saveUserData(UserData.defaultData)
+
+        let updated = await service.syncBodyMassToProfile()
+        XCTAssertTrue(updated)
+        let stored = UserDataManager.shared.loadUserData()
+        XCTAssertEqual(stored.weight, 72.5, accuracy: 0.0001)
+        XCTAssertNotNil(stored.weightUpdatedAt)
+    }
+
+    func test_syncBodyMass_skips_whenSampleOlder() async {
+        let service = MockHealthKitService()
+        let now = Date()
+        UserDataManager.shared.saveUserData(UserData(
+            weight: 80.0,
+            weightUnit: WeightUnit.kilograms.rawValue,
+            ftp: 250,
+            trainingHoursPerWeek: 6,
+            trainingGoal: TrainingGoal.getFaster.rawValue,
+            weightUpdatedAt: now
+        ))
+        service.bodyMass = (mass: 60.0, date: now.addingTimeInterval(-3600))
+
+        let updated = await service.syncBodyMassToProfile()
+        XCTAssertFalse(updated)
+        XCTAssertEqual(UserDataManager.shared.loadUserData().weight, 80.0, accuracy: 0.0001)
+    }
+
+    func test_syncBodyMass_noop_whenServiceUnavailable() async {
+        let service = MockHealthKitService()
+        service.isAvailable = false
+        service.bodyMass = (mass: 50.0, date: Date())
+        UserDataManager.shared.saveUserData(UserData.defaultData)
+
+        let updated = await service.syncBodyMassToProfile()
+        XCTAssertFalse(updated)
+        XCTAssertEqual(UserDataManager.shared.loadUserData().weight, 70.0, accuracy: 0.0001)
+    }
+
+    func test_updateWeightFromHealth_skipsStaleSample_whenNoPriorHealthSync() {
+        // Profile has no weightUpdatedAt (manual entry). Old HK sample shouldn't clobber it.
+        UserDataManager.shared.saveUserData(UserData.defaultData)
+        let now = Date()
+        let stale = now.addingTimeInterval(-60 * 24 * 60 * 60) // 60 days ago
+
+        let updated = UserDataManager.shared.updateWeightFromHealth(
+            kg: 99.0, sampleDate: stale, now: now
+        )
+        XCTAssertFalse(updated)
+        XCTAssertEqual(UserDataManager.shared.loadUserData().weight, 70.0, accuracy: 0.0001)
+    }
+
+    func test_updateWeightFromHealth_acceptsRecentSample_whenNoPriorHealthSync() {
+        UserDataManager.shared.saveUserData(UserData.defaultData)
+        let now = Date()
+        let recent = now.addingTimeInterval(-3600)
+
+        let updated = UserDataManager.shared.updateWeightFromHealth(
+            kg: 75.0, sampleDate: recent, now: now
+        )
+        XCTAssertTrue(updated)
+        XCTAssertEqual(UserDataManager.shared.loadUserData().weight, 75.0, accuracy: 0.0001)
+    }
+
+    // MARK: - Codable backward compatibility
+
+    func test_userData_decodes_legacyJSONWithoutWeightUpdatedAt() throws {
+        let json = """
+        {
+          "weight": 68.5,
+          "weightUnit": "kg",
+          "ftp": 240,
+          "trainingHoursPerWeek": 7,
+          "trainingGoal": "Get Faster"
+        }
+        """.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(UserData.self, from: json)
+        XCTAssertEqual(decoded.weight, 68.5)
+        XCTAssertEqual(decoded.ftp, 240)
+        XCTAssertNil(decoded.weightUpdatedAt)
+    }
+
+    // MARK: - Workout completion → HealthKit write-through
+
+    func test_markCompleted_writesToHealthKit_whenToggleOn() async {
+        let service = MockHealthKitService()
+        let manager = WorkoutManager(defaults: defaults, healthKitService: service)
+        defaults.set(true, forKey: WorkoutManager.healthSyncEnabledKey)
+
+        let workout = makeWorkout()
+        let summary = CompletedWorkoutSummary(
+            start: Date(timeIntervalSince1970: 1_000_000),
+            end: Date(timeIntervalSince1970: 1_003_600),
+            averageHeartRate: 150,
+            averagePowerWatts: 220
+        )
+        let completed = await manager.markWorkoutCompleted(workout, summary: summary)
+
+        XCTAssertEqual(completed.status, .completed)
+        XCTAssertEqual(service.savedSummaries.count, 1)
+        XCTAssertEqual(service.savedSummaries.first?.averagePowerWatts, 220)
+        // Persisted status is updated.
+        XCTAssertEqual(manager.loadWorkouts().first?.status, .completed)
+    }
+
+    func test_markCompleted_skipsHealthKit_whenToggleOff() async {
+        let service = MockHealthKitService()
+        let manager = WorkoutManager(defaults: defaults, healthKitService: service)
+        defaults.set(false, forKey: WorkoutManager.healthSyncEnabledKey)
+
+        let workout = makeWorkout()
+        let summary = CompletedWorkoutSummary(start: Date(), end: Date().addingTimeInterval(60))
+        _ = await manager.markWorkoutCompleted(workout, summary: summary)
+
+        XCTAssertTrue(service.savedSummaries.isEmpty)
+        XCTAssertEqual(manager.loadWorkouts().first?.status, .completed)
+    }
+
+    func test_markCompleted_persistsStatus_evenWhenHealthKitFails() async {
+        let service = MockHealthKitService()
+        service.saveError = HealthKitServiceError.notAuthorized
+        let manager = WorkoutManager(defaults: defaults, healthKitService: service)
+        defaults.set(true, forKey: WorkoutManager.healthSyncEnabledKey)
+
+        let workout = makeWorkout()
+        let summary = CompletedWorkoutSummary(start: Date(), end: Date().addingTimeInterval(60))
+        _ = await manager.markWorkoutCompleted(workout, summary: summary)
+
+        XCTAssertEqual(manager.loadWorkouts().first?.status, .completed)
+    }
+
+    // MARK: - Helpers
+
+    private func makeWorkout() -> Workout {
+        Workout(
+            title: "Test Ride",
+            date: Date(),
+            summary: "Easy spin",
+            intervals: [Interval(watts: 180, duration: 60)]
+        )
+    }
+}

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -24,9 +24,10 @@ This project is a SwiftUI-based iOS cycling training application.
 
 #### Dropped/Models/
 
-- **UserData.swift**: Core user, workout, interval, and workout-day models. Also contains persisted `UserDataManager` and `WorkoutManager` storage helpers.
+- **UserData.swift**: Core user, workout, interval, and workout-day models. Also contains persisted `UserDataManager` and `WorkoutManager` storage helpers. `UserDataManager` exposes `updateWeightFromHealth(kg:sampleDate:)` for HealthKit sync, and `WorkoutManager` exposes `markWorkoutCompleted(_:summary:)` which writes to HealthKit when the user has enabled `WorkoutManager.healthSyncEnabledKey`.
 - **WorkoutType.swift**: Enum defining AI workout types: endurance, threshold, VO2 max, sprint, and recovery.
 - **AIWorkoutGenerator.swift**: OpenAI chat-completions client for generated workouts. Reads API keys from configuration, requests a strict JSON schema, and converts responses into `Workout` models.
+- **HealthKitService.swift**: HealthKit integration. Defines the `HealthKitServicing` protocol, default `HealthKitService` implementation backed by `HKHealthStore` + `HKWorkoutBuilder`, the `CompletedWorkoutSummary` value type used to write cycling workouts, energy estimation helpers, and a `syncBodyMassToProfile(using:)` extension that pushes newer Health weights into `UserDataManager`. Simulator/macOS-safe via availability gates.
 
 #### Dropped/ViewModels/
 
@@ -52,6 +53,7 @@ This project is a SwiftUI-based iOS cycling training application.
 
 - **OnboardingViewModelTests.swift**: Unit tests for onboarding validation, unit conversion, and user-data saving.
 - **UserDataTests.swift**: Unit tests for unit conversion, user-data persistence, onboarding completion, and workout persistence reset behavior.
+- **HealthKitServiceTests.swift**: Unit tests for the HealthKit integration. Uses a `MockHealthKitService` to verify body-mass sync logic, energy estimation math, and `WorkoutManager.markWorkoutCompleted` write-through behavior driven by the Health-sync toggle.
 
 ### DroppedUITests/
 


### PR DESCRIPTION
## Why

Dropped riders already track their weight, FTP, and workouts in Apple Health. Re-entering that data in the app is friction, and completed workouts done here never made it back into their Health activity history. This PR wires HealthKit in both directions so the rider profile stays current and finished rides show up alongside everything else they do.

## Approach

A protocol-based `HealthKitServicing` is the seam between the app and `HKHealthStore`, so production code talks to a real HealthKit-backed implementation while tests inject a stub. All work is gated on `HKHealthStore.isHealthDataAvailable()` and on `#if canImport(HealthKit) && !os(macOS)` so the app stays buildable across the project's iOS / macOS / visionOS targets and is a graceful no-op on the simulator.

**Reads** (body mass, resting HR, VO2 max, and on iOS 17+ cycling FTP) use a small `HKSampleQuery` helper that returns the most recent quantity sample. Body mass flows through `UserDataManager.updateWeightFromHealth(...)`, which only overwrites the profile when the Health sample is genuinely newer; a new optional `weightUpdatedAt` field on `UserData` tracks provenance, and a 30-day recency guard prevents stale Health data from clobbering a weight the user just typed in onboarding.

**Writes** go through `HKWorkoutBuilder` with `.cycling` activity type. `CompletedWorkoutSummary` carries duration, optional kcal, average HR, average power, distance, and an indoor/outdoor flag. When kcal is not supplied we estimate from `power × time` using a typical cycling gross efficiency of ~23%, since `activeEnergyBurned` expects metabolic energy, not mechanical work. Distance and HR samples are added when available.

The "mark workout complete" UI doesn't exist yet (sister session's scope), so the integration point is `WorkoutManager.markWorkoutCompleted(_:summary:)`. It always persists status, and conditionally writes to HealthKit when the user toggle is on. Settings gets an "Apple Health" section with the toggle, a re-request permissions button, and a status row; the toggle is rolled back automatically if authorization fails or is unavailable.

## Notes for reviewers

- **Entitlement + Info.plist**: added `com.apple.developer.healthkit` to `Dropped.entitlements` and `INFOPLIST_KEY_NSHealthShareUsageDescription` / `NSHealthUpdateUsageDescription` to both Debug and Release configs (the project uses `GENERATE_INFOPLIST_FILE = YES`).
- **Backward compat**: `UserData` got a new optional `weightUpdatedAt`. There's a regression test that decodes legacy JSON without the field to confirm existing persisted profiles still load.
- **Calorie estimate** trade-off: 23% efficiency is a reasonable midpoint; callers that have a better number (power meter + metabolic data) should pass `totalEnergyKilocalories` directly to bypass the estimate.
- **Default location** is `.indoor` since structured power workouts in this app are typically trainer rides; callers can flip `isIndoor: false` when the workout is known to be outside.
- **Tests** use a `MockHealthKitService` so nothing touches the real `HKHealthStore`. Coverage: kcal math, body-mass sync (newer / older / stale-with-no-prior-sync / unavailable), `markWorkoutCompleted` write-through (toggle on, off, and HealthKit-failure path), and legacy `UserData` decode.

Co-authored-by: Copilot &lt;223556219+Copilot@users.noreply.github.com&gt;